### PR TITLE
Replace global registry request API with replication

### DIFF
--- a/proof_of_concept/asset.py
+++ b/proof_of_concept/asset.py
@@ -30,15 +30,17 @@ class Metadata:
 class Asset:
     """Asset, a representation of a computation or piece of data."""
 
-    def __init__(self, id: str, data: Any, metadata: Optional[Metadata] = None):
+    def __init__(
+            self, id: str, data: Any, metadata: Optional[Metadata] = None):
         """Constructor.
 
         Args:
             id: Name of the asset
             data: Data related to the asset
             metadata: Metadata related to the asset. If no metadata is
-                passed, metadata is set to a niljob, indicating that this is
-                an asset that is not the product of some workflow.
+                passed, metadata is set to a niljob, indicating that
+                this is an asset that is not the product of some
+                workflow.
 
         """
         if metadata is None:

--- a/proof_of_concept/ddm_client.py
+++ b/proof_of_concept/ddm_client.py
@@ -6,7 +6,10 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from proof_of_concept.definitions import (
         IAssetStore, ILocalWorkflowRunner, IPolicyServer, Metadata, Plan)
 from proof_of_concept.workflow import Job, Workflow
-from proof_of_concept.registry import global_registry
+from proof_of_concept.registry import (
+        global_registry, AssetStoreDescription, RegisteredObject,
+        NamespaceDescription, PolicyServerDescription, RunnerDescription)
+from proof_of_concept.replication import Replica
 
 
 class DDMClient:
@@ -18,6 +21,8 @@ class DDMClient:
             party: The party on whose behalf this client acts.
         """
         self._party = party
+        self._registry_replica = Replica[RegisteredObject](
+                global_registry.replication_server)
 
     def register_party(
             self, name: str, namespace: str, public_key: RSAPublicKey) -> None:
@@ -30,16 +35,26 @@ class DDMClient:
         """
         global_registry.register_party(name, namespace, public_key)
 
+    def register_site(self, name: str, admin_name: str) -> None:
+        """Register a site with the Registry.
+
+        Args:
+            name: Name of the site.
+            admin_name: Name of the administrating party.
+        """
+        global_registry.register_site(name, admin_name)
+
     def register_runner(
-            self, admin: str, runner: ILocalWorkflowRunner
+            self, site_name: str, admin_name: str, runner: ILocalWorkflowRunner
             ) -> None:
         """Register a LocalWorkflowRunner with the Registry.
 
         Args:
-            admin: The party administrating this runner.
+            site_name: Name of the site where this runner is.
+            admin_name: The party administrating this runner.
             runner: The runner to register.
         """
-        global_registry.register_runner(admin, runner)
+        global_registry.register_runner(site_name, admin_name, runner)
 
     def register_store(self, admin: str, store: IAssetStore) -> None:
         """Register a AssetStore with the Registry.
@@ -51,15 +66,17 @@ class DDMClient:
         global_registry.register_store(admin, store)
 
     def register_policy_server(
-            self, namespace: str, server: IPolicyServer) -> None:
+            self, site_name: str, namespace: str, server: IPolicyServer
+            ) -> None:
         """Register a policy server with the registry.
 
         Args:
+            site_name: The site at which this server is located.
             namespace: The namespace containing the assets this policy
                     server serves policy for.
             server: The data store to register.
         """
-        global_registry.register_policy_server(namespace, server)
+        global_registry.register_policy_server(site_name, namespace, server)
 
     def register_asset(self, asset_id: str, store_name: str) -> None:
         """Register an Asset with the Registry.
@@ -72,24 +89,40 @@ class DDMClient:
 
     def get_public_key_for_ns(self, namespace: str) -> RSAPublicKey:
         """Get the public key of the owner of a namespace."""
-        owner = global_registry.get_ns_owner(namespace)
-        return global_registry.get_public_key(owner)
+        owner = None
+        self._registry_replica.update()
+        for o in self._registry_replica.objects:
+            if isinstance(o, NamespaceDescription) and o.name == namespace:
+                return o.owner.public_key
+        raise RuntimeError('Namespace {} not found'.format(namespace))
 
     def list_runners(self) -> List[str]:
         """Returns a list of id's of available runners."""
-        return global_registry.list_runners()
+        self._registry_replica.update()
+        runners = list()    # type: List[str]
+        for o in self._registry_replica.objects:
+            if isinstance(o, RunnerDescription):
+                runners.append(o.runner.name)
+        return runners
 
-    def get_target_store(self, runner_id: str) -> str:
-        """Returns the id of the target store of the given runner."""
-        return global_registry.get_runner(runner_id).target_store()
+    def get_target_store(self, runner_name: str) -> str:
+        """Returns the name of the target store of the given runner."""
+        runner_desc = self._get_runner(runner_name)
+        return runner_desc.runner.target_store()
 
-    def get_runner_administrator(self, runner_id: str) -> str:
-        """Returns the id of the party administrating a runner."""
-        return global_registry.get_runner_admin(runner_id)
+    def get_runner_administrator(self, runner_name: str) -> str:
+        """Returns the name of the party administrating a runner."""
+        self._registry_replica.update()
+        for o in self._registry_replica.objects:
+            if isinstance(o, RunnerDescription):
+                if o.runner.name == runner_name:
+                    return o.site.admin.name
+        raise RuntimeError('Runner {} not found'.format(runner_name))
 
-    def get_store_administrator(self, store_id: str) -> str:
-        """Returns the id of the party administrating a store."""
-        return global_registry.get_store_admin(store_id)
+    def get_store_administrator(self, store_name: str) -> str:
+        """Returns the name of the party administrating a store."""
+        store = self._get_store(store_name)
+        return store.site.admin.name
 
     def list_policy_servers(self) -> List[Tuple[str, IPolicyServer]]:
         """List all known policy servers.
@@ -98,7 +131,13 @@ class DDMClient:
             A list of all registered policy servers and their
                     namespaces.
         """
-        return global_registry.list_policy_servers()
+        self._registry_replica.update()
+
+        result = list()     # type: List[Tuple[str, IPolicyServer]]
+        for o in self._registry_replica.objects:
+            if isinstance(o, PolicyServerDescription):
+                result.append((o.namespace.name, o.server))
+        return result
 
     def get_asset_location(self, asset_id: str) -> str:
         """Returns the name of the store which stores this asset."""
@@ -107,8 +146,8 @@ class DDMClient:
     def retrieve_data(
             self, store_id: str, name: str) -> Tuple[Any, Metadata]:
         """Obtains a data item from a store."""
-        store = global_registry.get_store(store_id)
-        return store.retrieve(name, self._party)
+        store_desc = self._get_store(store_id)
+        return store_desc.store.retrieve(name, self._party)
 
     def submit_job(
             self, runner_id: str,
@@ -121,5 +160,23 @@ class DDMClient:
             job: The job to submit.
             plan: The plan to execute the workflow to.
         """
-        runner = global_registry.get_runner(runner_id)
-        return runner.execute_job(job, plan)
+        runner_desc = self._get_runner(runner_id)
+        return runner_desc.runner.execute_job(job, plan)
+
+    def _get_runner(self, runner_name: str) -> RunnerDescription:
+        """Returns the runner with the given name."""
+        self._registry_replica.update()
+        for o in self._registry_replica.objects:
+            if isinstance(o, RunnerDescription):
+                if o.runner.name == runner_name:
+                    return o
+        raise RuntimeError('Runner {} not found'.format(runner_name))
+
+    def _get_store(self, store_name: str) -> AssetStoreDescription:
+        """Returns the store with the given name."""
+        self._registry_replica.update()
+        for o in self._registry_replica.objects:
+            if isinstance(o, AssetStoreDescription):
+                if o.store.name == store_name:
+                    return o
+        raise RuntimeError('Store {} not found'.format(store_name))

--- a/proof_of_concept/ddm_site.py
+++ b/proof_of_concept/ddm_site.py
@@ -47,8 +47,11 @@ class Site:
                 backend=default_backend())
 
         self._ddm_client.register_party(
-                self.name, self.namespace,
+                self.administrator, self.namespace,
                 self._private_key.public_key())
+
+        # Register site with DDM
+        self._ddm_client.register_site(self.name + '-site', administrator)
 
         # Policy support
         self._policy_archive = ReplicableArchive[Rule]()
@@ -59,7 +62,7 @@ class Site:
         self.policy_server = ReplicationServer[Rule](
                 self._policy_archive, 10.0)
         self._ddm_client.register_policy_server(
-                self.namespace, self.policy_server)
+                self.name + '-site', self.namespace, self.policy_server)
 
         self._policy_source = PolicySource(
                 self._ddm_client, self._policy_store)
@@ -67,7 +70,7 @@ class Site:
 
         # Server side
         self.store = AssetStore(name + '-store', self._policy_evaluator)
-        self._ddm_client.register_store(administrator, self.store)
+        self._ddm_client.register_store(self.name + '-site', self.store)
         for key, val in stored_data.items():
             self.store.store(key, val, Metadata(Job.niljob(key), 'dataset'))
             self._ddm_client.register_asset(key, self.store.name)
@@ -75,7 +78,8 @@ class Site:
         self.runner = LocalWorkflowRunner(
                 name + '-runner', administrator,
                 self._policy_evaluator, self.store)
-        self._ddm_client.register_runner(administrator, self.runner)
+        self._ddm_client.register_runner(
+               self.name + '-site', administrator, self.runner)
 
         # Client side
         self._workflow_engine = GlobalWorkflowRunner(

--- a/proof_of_concept/policy_replication.py
+++ b/proof_of_concept/policy_replication.py
@@ -42,6 +42,11 @@ class RuleValidator(ObjectValidator[Rule]):
         return rule.has_valid_signature(self._key)
 
 
+# Defining this where it's used makes mypy crash.
+# See https://github.com/python/mypy/issues/7281
+_OtherStores = Dict[IReplicationServer[Rule], Replica[Rule]]
+
+
 class PolicySource(IPolicySource):
     """Ties together various sources of policies."""
     def __init__(
@@ -57,8 +62,7 @@ class PolicySource(IPolicySource):
         """
         self._ddm_client = ddm_client
         self._our_store = our_store
-        OtherStores = Dict[IReplicationServer[Rule], Replica[Rule]]
-        self._other_stores = dict()     # type: OtherStores
+        self._other_stores = dict()     # type: _OtherStores
 
     def policies(self) -> Iterable[Rule]:
         """Returns the collected rules."""

--- a/proof_of_concept/registry.py
+++ b/proof_of_concept/registry.py
@@ -229,11 +229,9 @@ class Registry:
             site_name: The site this store is located at.
             store: The data store to register.
         """
-        for o in self._store.objects():
-            if isinstance(o, AssetStoreDescription) and o.store == store:
-                raise RuntimeError(
-                        'There is already a store called {}'.format(
-                            store.name))
+        if self._in_store(AssetStoreDescription, 'store', store):
+            raise RuntimeError(
+                    'There is already a store called {}'.format(store.name))
 
         site = self._get_object(SiteDescription, 'name', site_name)
         if site is None:

--- a/proof_of_concept/registry.py
+++ b/proof_of_concept/registry.py
@@ -175,8 +175,7 @@ class Registry:
             public_key: Public key of this party.
         """
         if self._in_store(PartyDescription, 'name', name):
-            raise RuntimeError(
-                    'There is already a party called {}'.format(name))
+            raise RuntimeError(f'There is already a party called {name}')
 
         party_desc = PartyDescription(name, public_key)
         self._store.insert(party_desc)
@@ -191,12 +190,11 @@ class Registry:
 
         """
         if self._in_store(SiteDescription, 'name', name):
-            raise RuntimeError(
-                    'There is already a site called {}'.format(name))
+            raise RuntimeError(f'There is already a site called {name}')
 
         admin = self._get_object(PartyDescription, 'name', admin_name)
         if admin is None:
-            raise RuntimeError('Party {} not found'.format(admin_name))
+            raise RuntimeError(f'Party {admin_name} not found')
 
         site_desc = SiteDescription(name, admin)
         self._store.insert(site_desc)
@@ -213,11 +211,11 @@ class Registry:
         """
         if self._in_store(RunnerDescription, 'runner', runner):
             raise RuntimeError(
-                    'There is already a runner called {}'.format(runner.name))
+                    f'There is already a runner called {runner.name}')
 
         site = self._get_object(SiteDescription, 'name', site_name)
         if site is None:
-            raise RuntimeError('Site {} not found'.format(site_name))
+            raise RuntimeError(f'Site {site_name} not found')
 
         runner_desc = RunnerDescription(site, runner)
         self._store.insert(runner_desc)
@@ -230,12 +228,11 @@ class Registry:
             store: The data store to register.
         """
         if self._in_store(AssetStoreDescription, 'store', store):
-            raise RuntimeError(
-                    'There is already a store called {}'.format(store.name))
+            raise RuntimeError(f'There is already a store called {store}')
 
         site = self._get_object(SiteDescription, 'name', site_name)
         if site is None:
-            raise RuntimeError('Site {} not found'.format(site_name))
+            raise RuntimeError(f'Site {site_name} not found')
 
         store_desc = AssetStoreDescription(site, store)
         self._store.insert(store_desc)
@@ -252,16 +249,16 @@ class Registry:
             server: The data store to register.
         """
         if self._in_store(PolicyServerDescription, 'server', server):
-            raise RuntimeError('The server is already registered')
+            raise RuntimeError(f'Server {server} is already registered')
 
         site = self._get_object(SiteDescription, 'name', site_name)
         if site is None:
-            raise RuntimeError('Site {} not found'.format(site_name))
+            raise RuntimeError(f'Site {site_name} not found')
 
         namespace = self._get_object(
                 NamespaceDescription, 'name', namespace_name)
         if namespace is None:
-            raise RuntimeError('Namespace {} not found'.format(namespace_name))
+            raise RuntimeError(f'Namespace {namespace_name} not found')
 
         server_desc = PolicyServerDescription(site, namespace, server)
         self._store.insert(server_desc)

--- a/proof_of_concept/registry.py
+++ b/proof_of_concept/registry.py
@@ -158,7 +158,7 @@ class Registry:
     """
     def __init__(self) -> None:
         """Create a new registry."""
-        self._assets = dict()           # type: Dict[str, str]
+        self._asset_locations = dict()           # type: Dict[str, str]
 
         self._archive = ReplicableArchive[RegisteredObject]()
         self._store = CanonicalStore[RegisteredObject](self._archive)
@@ -270,9 +270,9 @@ class Registry:
             asset_id: The id of the asset to register.
             store_name: Name of the store where it can be found.
         """
-        if asset_id in self._assets:
+        if asset_id in self._asset_locations:
             raise RuntimeError('There is already an asset with this name')
-        self._assets[asset_id] = store_name
+        self._asset_locations[asset_id] = store_name
 
     def get_asset_location(self, asset_id: str) -> str:
         """Returns the name of the store this asset is in.
@@ -286,7 +286,7 @@ class Registry:
         Raises:
             KeyError: If no asset with the given id is registered.
         """
-        return self._assets[asset_id]
+        return self._asset_locations[asset_id]
 
     def _get_object(
             self, typ: Type[_ReplicatedClass], attr_name: str, value: Any

--- a/proof_of_concept/registry.py
+++ b/proof_of_concept/registry.py
@@ -5,6 +5,145 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from proof_of_concept.definitions import (
         IAssetStore, ILocalWorkflowRunner, IPolicyServer)
+from proof_of_concept.replication import (
+        CanonicalStore, ReplicableArchive, ReplicationServer)
+
+
+class RegisteredObject:
+    """A parent class for DDM-wide metadata classes.
+
+    This is here mainly because it's required for the replication
+    system.
+
+    """
+    pass
+
+
+class PartyDescription(RegisteredObject):
+    """Describes a Party to the rest of the DDM.
+
+    Attributes:
+        name: Name of the party.
+        public_key: The party's public key for signing rules.
+
+    """
+    def __init__(self, name: str, public_key: RSAPublicKey) -> None:
+        """Create a PartyDescription.
+
+        Args:
+            name: Name of the party.
+            public_key: The party's public key for signing rules.
+        """
+        self.name = name
+        self.public_key = public_key
+
+
+class NamespaceDescription(RegisteredObject):
+    """Describes a namespace to the rest of the DDM.
+
+    Attributes:
+        name: Name of the namespace (i.e. the prefix)
+        owner: Party which owns the namespace and assets in it.
+
+    """
+    def __init__(self, name: str, owner: PartyDescription) -> None:
+        """Create a NamespaceDescription.
+
+        Args:
+            name: Name of the namespace (i.e. the prefix)
+            owner: Party which owns the namespace and assets in it.
+
+        """
+        self.name = name
+        self.owner = owner
+
+
+class SiteDescription(RegisteredObject):
+    """Describes a site to the rest of the DDM.
+
+    Attributes:
+        name: Name of the site.
+        admin: Party which administrates this site.
+
+    """
+    def __init__(self, name: str, admin: PartyDescription) -> None:
+        """Create a SiteDescription.
+
+        Args:
+            name: Name of the site.
+            admin: Party which administrates this site.
+
+        """
+        self.name = name
+        self.admin = admin
+
+
+class RunnerDescription(RegisteredObject):
+    """Describes a workflow runner to the rest of the DDM.
+
+    Attributes:
+        site: Site at which this runner is located.
+        runner: The runner service.
+
+    """
+    def __init__(
+            self, site: SiteDescription, runner: ILocalWorkflowRunner
+            ) -> None:
+        """Create a RunnerDescription.
+
+        Args:
+            site: Site at which this runner is located.
+            runner: The runner service.
+
+        """
+        self.site = site
+        self.runner = runner
+
+
+class AssetStoreDescription(RegisteredObject):
+    """Describes an asset store to the rest of the DDM.
+
+    Attributes:
+        site: The site at which this store is located.
+        store: The store service.
+
+    """
+    def __init__(
+            self, site: SiteDescription, store: IAssetStore
+            ) -> None:
+        """Create an AssetStoreDescription.
+
+        Args:
+            site: The site at which this store is located.
+            store: The store service.
+
+        """
+        self.site = site
+        self.store = store
+
+
+class PolicyServerDescription(RegisteredObject):
+    """Describes a policy server to the rest of the DDM.
+
+    Attributes:
+        namespace: The namespace governed by this server.
+        site: The site at which this server is located.
+
+    """
+    def __init__(
+            self, site: SiteDescription, namespace: NamespaceDescription,
+            server: IPolicyServer) -> None:
+        """Create a PolicyServerDescription.
+
+        Args:
+            site: The site at which this server is located.
+            namespace: The namespace governed by this server.
+            server: The policy server.
+
+        """
+        self.site = site
+        self.namespace = namespace
+        self.server = server
 
 
 class Registry:
@@ -16,15 +155,12 @@ class Registry:
     """
     def __init__(self) -> None:
         """Create a new registry."""
-        self._party_namespaces = dict()     # type: Dict[str, str]
-        self._party_keys = dict()       # type: Dict[str, RSAPublicKey]
-        self._ns_owners = dict()        # type: Dict[str, str]
-        self._runners = dict()          # type: Dict[str, ILocalWorkflowRunner]
-        self._runner_admins = dict()    # type: Dict[str, str]
-        self._stores = dict()           # type: Dict[str, IAssetStore]
-        self._store_admins = dict()     # type: Dict[str, str]
-        self._policy_servers = dict()   # type: Dict[str, IPolicyServer]
         self._assets = dict()           # type: Dict[str, str]
+
+        self._archive = ReplicableArchive[RegisteredObject]()
+        self._store = CanonicalStore[RegisteredObject](self._archive)
+        self.replication_server = ReplicationServer[RegisteredObject](
+                self._archive, 1.0)
 
     def register_party(
             self, name: str, namespace: str, public_key: RSAPublicKey) -> None:
@@ -35,49 +171,102 @@ class Registry:
             namespace: ID namespace owned by this party.
             public_key: Public key of this party.
         """
-        if name in self._party_namespaces:
-            raise RuntimeError('There is already a party with this name')
-        self._party_namespaces[name] = namespace
-        self._party_keys[name] = public_key
-        self._ns_owners[namespace] = name
+        for i in self._store.objects():
+            if isinstance(i, PartyDescription) and i.name == name:
+                raise RuntimeError('There is already a party called {}'.format(
+                    name))
+
+        party_desc = PartyDescription(name, public_key)
+        self._store.insert(party_desc)
+        self._store.insert(NamespaceDescription(namespace, party_desc))
+
+    def register_site(self, name: str, admin_name: str) -> None:
+        """Register a Site with the Registry.
+
+        Args:
+            name: Name of the site.
+            admin_name: Party administrating this site.
+
+        """
+        for o in self._store.objects():
+            if isinstance(o, SiteDescription) and o.name == name:
+                raise RuntimeError('There is already a site called {}'.format(
+                    name))
+
+        for o in self._store.objects():
+            if isinstance(o, PartyDescription) and o.name == admin_name:
+                admin = o
+                break
+        else:
+            raise RuntimeError('Party {} not found'.format(admin_name))
+
+        site_desc = SiteDescription(name, admin)
+        self._store.insert(site_desc)
 
     def register_runner(
-            self, admin: str, runner: ILocalWorkflowRunner
+            self, site_name: str, admin: str, runner: ILocalWorkflowRunner
             ) -> None:
         """Register a LocalWorkflowRunner with the Registry.
 
         Args:
+            site_name: Name of the site where the runner is located.
             admin: The party administrating this runner.
             runner: The runner to register.
         """
-        if runner.name in self._runners:
-            raise RuntimeError('There is already a runner with this name')
-        self._runners[runner.name] = runner
-        self._runner_admins[runner.name] = admin
+        for i in self._store.objects():
+            if isinstance(i, RunnerDescription) and i.runner == runner:
+                raise RuntimeError(
+                        'There is already a runner called {}'.format(
+                            runner.name))
 
-    def register_store(self, admin: str, store: IAssetStore) -> None:
+        site = self._get_site(site_name)
+        runner_desc = RunnerDescription(site, runner)
+        self._store.insert(runner_desc)
+
+    def register_store(self, site_name: str, store: IAssetStore) -> None:
         """Register an AssetStore with the Registry.
 
         Args:
-            admin: The party administrating this runner.
+            site_name: The site this store is located at.
             store: The data store to register.
         """
-        if store.name in self._stores:
-            raise RuntimeError('There is already a store with this name')
-        self._stores[store.name] = store
-        self._store_admins[store.name] = admin
+        for o in self._store.objects():
+            if isinstance(o, AssetStoreDescription) and o.store == store:
+                raise RuntimeError(
+                        'There is already a store called {}'.format(
+                            store.name))
+
+        site = self._get_site(site_name)
+        store_desc = AssetStoreDescription(site, store)
+        self._store.insert(store_desc)
 
     def register_policy_server(
-            self, namespace: str, server: IPolicyServer) -> None:
+            self, site_name: str, namespace_name: str, server: IPolicyServer
+            ) -> None:
         """Register a PolicyServer with the registry.
 
         Args:
-            namespace: The namespace this server serves policies for.
+            site_name: Site at which this server is located.
+            namespace_name: The namespace this server serves policies
+                    for.
             server: The data store to register.
         """
-        if server in self._policy_servers:
-            raise RuntimeError('This server is already registered')
-        self._policy_servers[namespace] = server
+        for o in self._store.objects():
+            if isinstance(o, PolicyServerDescription) and o.server == server:
+                raise RuntimeError('The server is already registered')
+
+        site = self._get_site(site_name)
+
+        for o in self._store.objects():
+            if isinstance(o, NamespaceDescription):
+                if o.name == namespace_name:
+                    namespace = o
+                    break
+        else:
+            raise RuntimeError('Namespace {} not found'.format(namespace_name))
+
+        server_desc = PolicyServerDescription(site, namespace, server)
+        self._store.insert(server_desc)
 
     def register_asset(self, asset_id: str, store_name: str) -> None:
         """Register an Asset with the Registry.
@@ -89,110 +278,6 @@ class Registry:
         if asset_id in self._assets:
             raise RuntimeError('There is already an asset with this name')
         self._assets[asset_id] = store_name
-
-    def get_ns_owner(self, namespace: str) -> str:
-        """Returns the name of the party owning a namespace.
-
-        Args:
-            namespace: Namespace to look up
-
-        Return:
-            Name of the owner of the namespace.
-
-        Raises:
-            KeyError: If no namespace with the given name is
-                    registered.
-        """
-        return self._ns_owners[namespace]
-
-    def get_public_key(self, party: str) -> RSAPublicKey:
-        """Returns the public key of the given party.
-
-        Args:
-            party: Name of the party to look up.
-
-        Return:
-            The public key of the given party.
-
-        Raises:
-            KeyError: If no party with the given name is registered.
-        """
-        return self._party_keys[party]
-
-    def list_runners(self) -> List[str]:
-        """List names of all registered runners.
-
-        Returns:
-            A list of names as strings.
-        """
-        return list(self._runners.keys())
-
-    def get_runner(self, name: str) -> ILocalWorkflowRunner:
-        """Look up a LocalWorkflowRunner.
-
-        Args:
-            name: The name of the runner to look up.
-
-        Return:
-            The runner with that name.
-
-        Raises:
-            KeyError: If no runner with the given name is
-                    registered.
-        """
-        return self._runners[name]
-
-    def get_runner_admin(self, name: str) -> str:
-        """Look up who administrates a given runner.
-
-        Args:
-            name: The name of the runner to look up.
-
-        Return:
-            The name of the party administrating it.
-
-        Raises:
-            KeyError: If no runner with the given name is regstered.
-        """
-        return self._runner_admins[name]
-
-    def get_store(self, name: str) -> IAssetStore:
-        """Look up an AssetStore.
-
-        Args:
-            name: The name of the store to look up.
-
-        Return:
-            The store with that name.
-
-        Raises:
-            KeyError: If no store with the given name is currently
-                    registered.
-        """
-        return self._stores[name]
-
-    def get_store_admin(self, name: str) -> str:
-        """Look up who administrates a given store.
-
-        Args:
-            name: The name of the store to look up.
-
-        Return:
-            The name of the party administrating it.
-
-        Raises:
-            KeyError: If no runner with the given name is registered.
-        """
-        return self._store_admins[name]
-
-    def list_policy_servers(self) -> List[Tuple[str, IPolicyServer]]:
-        """List all known policy servers.
-
-        Return:
-            A list of all registered policy servers and their
-                    namespaces.
-        """
-        return list(self._policy_servers.items())
 
     def get_asset_location(self, asset_id: str) -> str:
         """Returns the name of the store this asset is in.
@@ -207,6 +292,14 @@ class Registry:
             KeyError: If no asset with the given id is registered.
         """
         return self._assets[asset_id]
+
+    def _get_site(self, site_name: str) -> SiteDescription:
+        """Returns the site of the given name, if registered."""
+        for o in self._store.objects():
+            if isinstance(o, SiteDescription) and o.name == site_name:
+                return o
+        else:
+            raise RuntimeError('Site {} not found'.format(site_name))
 
 
 global_registry = Registry()

--- a/proof_of_concept/registry.py
+++ b/proof_of_concept/registry.py
@@ -160,10 +160,10 @@ class Registry:
         """Create a new registry."""
         self._asset_locations = dict()           # type: Dict[str, str]
 
-        self._archive = ReplicableArchive[RegisteredObject]()
-        self._store = CanonicalStore[RegisteredObject](self._archive)
+        archive = ReplicableArchive[RegisteredObject]()
+        self._store = CanonicalStore[RegisteredObject](archive)
         self.replication_server = ReplicationServer[RegisteredObject](
-                self._archive, 1.0)
+                archive, 1.0)
 
     def register_party(
             self, name: str, namespace: str, public_key: RSAPublicKey) -> None:

--- a/proof_of_concept/replication.py
+++ b/proof_of_concept/replication.py
@@ -65,7 +65,7 @@ class CanonicalStore(Generic[T]):
     """Stores Replicables and can be replicated."""
 
     def __init__(self, archive: ReplicableArchive) -> None:
-        """Create a ReplicatedStore."""
+        """Create a CanonicalStore."""
         self._archive = archive
 
     def objects(self) -> Iterable[T]:
@@ -166,7 +166,7 @@ class ReplicationServer(IReplicationServer[T]):
 
         Args:
             archive: An archive to serve updates from.
-            max_lag: Maximum time replicas may be out of date.
+            max_lag: Maximum time (s) replicas may be out of date.
         """
         self._archive = archive
         self._max_lag = max_lag


### PR DESCRIPTION
The global registry had a direct API for discovering other sites and getting the location of their services. That doesn't scale. This pull request replaces that system with a replication-based solution using the existing replication system, which should work better for a small-data high-traffic data store.