### PR TITLE
Registry registers sites

### DIFF
--- a/proof_of_concept/asset_store.py
+++ b/proof_of_concept/asset_store.py
@@ -12,16 +12,11 @@ logger = logging.getLogger(__file__)
 
 class AssetStore(IAssetStore):
     """A simple store for assets."""
-    def __init__(self, name: str, policy_evaluator: PolicyEvaluator) -> None:
+    def __init__(self, policy_evaluator: PolicyEvaluator) -> None:
         """Create a new empty AssetStore."""
-        self.name = name
         self._policy_evaluator = policy_evaluator
         self._permission_calculator = PermissionCalculator(policy_evaluator)
         self._assets = dict()  # type: Dict[str, Asset]
-
-    def __repr__(self) -> str:
-        """Return a string representation of this object."""
-        return 'AssetStore({})'.format(self.name)
 
     def store(self, asset: Asset) -> None:
         """Stores an asset.

--- a/proof_of_concept/ddm_client.py
+++ b/proof_of_concept/ddm_client.py
@@ -5,7 +5,8 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from proof_of_concept.asset import Asset
 from proof_of_concept.definitions import (
-        IAssetStore, ILocalWorkflowRunner, IPolicyServer, Plan)
+        IAssetStore, ILocalWorkflowRunner, IPolicyServer, PartyDescription,
+        Plan)
 from proof_of_concept.workflow import Job, Workflow
 from proof_of_concept.registry import (
         global_registry, RegisteredObject, SiteDescription)
@@ -25,16 +26,14 @@ class DDMClient:
         self._registry_replica = Replica[RegisteredObject](
                 global_registry.replication_server)
 
-    def register_party(
-            self, name: str, public_key: RSAPublicKey) -> None:
+    def register_party(self, description: PartyDescription) -> None:
         """Register a party with the Registry.
 
         Args:
-            name: Name of the party.
-            public_key: Public key of this party.
+            description: Description of the party.
 
         """
-        global_registry.register_party(name, public_key)
+        global_registry.register_party(description)
 
     def register_site(
             self,

--- a/proof_of_concept/ddm_client.py
+++ b/proof_of_concept/ddm_client.py
@@ -1,5 +1,5 @@
 """Functionality for connecting to other DDM sites."""
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
@@ -8,8 +8,7 @@ from proof_of_concept.definitions import (
         IAssetStore, ILocalWorkflowRunner, IPolicyServer, Plan)
 from proof_of_concept.workflow import Job, Workflow
 from proof_of_concept.registry import (
-        global_registry, AssetStoreDescription, RegisteredObject,
-        NamespaceDescription, PolicyServerDescription, RunnerDescription)
+        global_registry, RegisteredObject, SiteDescription)
 from proof_of_concept.replication import Replica
 
 
@@ -27,62 +26,40 @@ class DDMClient:
                 global_registry.replication_server)
 
     def register_party(
-            self, name: str, namespace: str, public_key: RSAPublicKey) -> None:
+            self, name: str, public_key: RSAPublicKey) -> None:
         """Register a party with the Registry.
 
         Args:
             name: Name of the party.
-            namespace: ID namespace owned by this party.
             public_key: Public key of this party.
 
         """
-        global_registry.register_party(name, namespace, public_key)
+        global_registry.register_party(name, public_key)
 
-    def register_site(self, name: str, admin_name: str) -> None:
+    def register_site(
+            self,
+            name: str,
+            owner_name: str,
+            admin_name: str,
+            runner: Optional[ILocalWorkflowRunner] = None,
+            store: Optional[IAssetStore] = None,
+            namespace: Optional[str] = None,
+            policy_server: Optional[IPolicyServer] = None
+            ) -> None:
         """Register a site with the Registry.
 
         Args:
             name: Name of the site.
+            owner_name: Name of the owning party.
             admin_name: Name of the administrating party.
+            runner: This site's local workflow runner.
+            store: This site's asset store.
+            namespace: Namespace managed by this site's policy server.
+            policy_server: This site's policy server.
         """
-        global_registry.register_site(name, admin_name)
-
-    def register_runner(
-            self, site_name: str, admin_name: str, runner: ILocalWorkflowRunner
-            ) -> None:
-        """Register a LocalWorkflowRunner with the Registry.
-
-        Args:
-            site_name: Name of the site where this runner is.
-            admin_name: The party administrating this runner.
-            runner: The runner to register.
-
-        """
-        global_registry.register_runner(site_name, admin_name, runner)
-
-    def register_store(self, admin: str, store: IAssetStore) -> None:
-        """Register a AssetStore with the Registry.
-
-        Args:
-            admin: The party administrating this runner.
-            store: The data store to register.
-
-        """
-        global_registry.register_store(admin, store)
-
-    def register_policy_server(
-            self, site_name: str, namespace: str, server: IPolicyServer
-            ) -> None:
-        """Register a policy server with the registry.
-
-        Args:
-            site_name: The site at which this server is located.
-            namespace: The namespace containing the assets this policy
-                    server serves policy for.
-            server: The data store to register.
-
-        """
-        global_registry.register_policy_server(site_name, namespace, server)
+        global_registry.register_site(
+                name, owner_name, admin_name, runner, store, namespace,
+                policy_server)
 
     def register_asset(self, asset_id: str, store_name: str) -> None:
         """Register an Asset with the Registry.
@@ -99,8 +76,9 @@ class DDMClient:
         owner = None
         self._registry_replica.update()
         for o in self._registry_replica.objects:
-            if isinstance(o, NamespaceDescription) and o.name == namespace:
-                return o.owner.public_key
+            if isinstance(o, SiteDescription) and o.namespace is not None:
+                if o.namespace == namespace:
+                    return o.owner.public_key
         raise RuntimeError('Namespace {} not found'.format(namespace))
 
     def list_runners(self) -> List[str]:
@@ -108,28 +86,35 @@ class DDMClient:
         self._registry_replica.update()
         runners = list()    # type: List[str]
         for o in self._registry_replica.objects:
-            if isinstance(o, RunnerDescription):
-                runners.append(o.runner.name)
+            if isinstance(o, SiteDescription):
+                if o.runner is not None:
+                    runners.append(o.runner.name)
         return runners
 
     def get_target_store(self, runner_name: str) -> str:
         """Returns the name of the target store of the given runner."""
-        runner_desc = self._get_runner(runner_name)
-        return runner_desc.runner.target_store()
+        runner = self._get_runner(runner_name)
+        return runner.target_store()
 
     def get_runner_administrator(self, runner_name: str) -> str:
         """Returns the name of the party administrating a runner."""
         self._registry_replica.update()
         for o in self._registry_replica.objects:
-            if isinstance(o, RunnerDescription):
-                if o.runner.name == runner_name:
-                    return o.site.admin.name
+            if isinstance(o, SiteDescription):
+                if o.runner is not None:
+                    if o.runner.name == runner_name:
+                        return o.admin.name
         raise RuntimeError('Runner {} not found'.format(runner_name))
 
     def get_store_administrator(self, store_name: str) -> str:
         """Returns the name of the party administrating a store."""
-        store = self._get_store(store_name)
-        return store.site.admin.name
+        self._registry_replica.update()
+        for o in self._registry_replica.objects:
+            if isinstance(o, SiteDescription):
+                if o.store is not None:
+                    if o.store.name == store_name:
+                        return o.admin.name
+        raise RuntimeError('Store {} not found'.format(store_name))
 
     def list_policy_servers(self) -> List[Tuple[str, IPolicyServer]]:
         """List all known policy servers.
@@ -140,11 +125,11 @@ class DDMClient:
 
         """
         self._registry_replica.update()
-
         result = list()     # type: List[Tuple[str, IPolicyServer]]
         for o in self._registry_replica.objects:
-            if isinstance(o, PolicyServerDescription):
-                result.append((o.namespace.name, o.server))
+            if isinstance(o, SiteDescription):
+                if o.namespace is not None and o.policy_server is not None:
+                    result.append((o.namespace, o.policy_server))
         return result
 
     @staticmethod
@@ -155,8 +140,8 @@ class DDMClient:
     def retrieve_asset(self, store_id: str, asset_id: str
                        ) -> Asset:
         """Obtains a data item from a store."""
-        store_desc = self._get_store(store_id)
-        return store_desc.store.retrieve(asset_id, self._party)
+        store = self._get_store(store_id)
+        return store.retrieve(asset_id, self._party)
 
     def submit_job(self, runner_id: str, job: Job, plan: Plan) -> None:
         """Submits a job for execution to a local runner.
@@ -167,23 +152,25 @@ class DDMClient:
             plan: The plan to execute the workflow to.
 
         """
-        runner_desc = self._get_runner(runner_id)
-        return runner_desc.runner.execute_job(job, plan)
+        runner = self._get_runner(runner_id)
+        return runner.execute_job(job, plan)
 
-    def _get_runner(self, runner_name: str) -> RunnerDescription:
+    def _get_runner(self, runner_name: str) -> ILocalWorkflowRunner:
         """Returns the runner with the given name."""
         self._registry_replica.update()
         for o in self._registry_replica.objects:
-            if isinstance(o, RunnerDescription):
-                if o.runner.name == runner_name:
-                    return o
-        raise RuntimeError('Runner {} not found'.format(runner_name))
+            if isinstance(o, SiteDescription):
+                if o.runner is not None:
+                    if o.runner.name == runner_name:
+                        return o.runner
+        raise RuntimeError(f'Runner {runner_name} not found')
 
-    def _get_store(self, store_name: str) -> AssetStoreDescription:
+    def _get_store(self, store_name: str) -> IAssetStore:
         """Returns the store with the given name."""
         self._registry_replica.update()
         for o in self._registry_replica.objects:
-            if isinstance(o, AssetStoreDescription):
-                if o.store.name == store_name:
-                    return o
+            if isinstance(o, SiteDescription):
+                if o.store is not None:
+                    if o.store.name == store_name:
+                        return o.store
         raise RuntimeError('Store {} not found'.format(store_name))

--- a/proof_of_concept/ddm_client.py
+++ b/proof_of_concept/ddm_client.py
@@ -81,35 +81,15 @@ class DDMClient:
                     return o.owner.public_key
         raise RuntimeError('Namespace {} not found'.format(namespace))
 
-    def list_runners(self) -> List[str]:
-        """Returns a list of id's of available runners."""
+    def list_sites_with_runners(self) -> List[str]:
+        """Returns a list of id's of sites with runners."""
         self._registry_replica.update()
-        runners = list()    # type: List[str]
+        sites = list()    # type: List[str]
         for o in self._registry_replica.objects:
             if isinstance(o, SiteDescription):
                 if o.runner is not None:
-                    runners.append(o.runner.name)
-        return runners
-
-    def get_target_site(self, runner_name: str) -> str:
-        """Returns the name of the site of the given runner."""
-        self._registry_replica.update()
-        for o in self._registry_replica.objects:
-            if isinstance(o, SiteDescription):
-                if o.runner is not None:
-                    if o.runner.name == runner_name:
-                        return o.name
-        raise RuntimeError('Runner {} not found'.format(runner_name))
-
-    def get_runner_administrator(self, runner_name: str) -> str:
-        """Returns the name of the party administrating a runner."""
-        self._registry_replica.update()
-        for o in self._registry_replica.objects:
-            if isinstance(o, SiteDescription):
-                if o.runner is not None:
-                    if o.runner.name == runner_name:
-                        return o.admin.name
-        raise RuntimeError('Runner {} not found'.format(runner_name))
+                    sites.append(o.name)
+        return sites
 
     def get_site_administrator(self, site_name: str) -> str:
         """Returns the name of the party administrating a site."""
@@ -147,27 +127,27 @@ class DDMClient:
         store = self._get_store(site_id)
         return store.retrieve(asset_id, self._party)
 
-    def submit_job(self, runner_id: str, job: Job, plan: Plan) -> None:
+    def submit_job(self, site_id: str, job: Job, plan: Plan) -> None:
         """Submits a job for execution to a local runner.
 
         Args:
-            runner_id: The runner to submit to.
+            site_id: The site to submit to.
             job: The job to submit.
             plan: The plan to execute the workflow to.
 
         """
-        runner = self._get_runner(runner_id)
+        runner = self._get_runner(site_id)
         return runner.execute_job(job, plan)
 
-    def _get_runner(self, runner_name: str) -> ILocalWorkflowRunner:
-        """Returns the runner with the given name."""
+    def _get_runner(self, site_name: str) -> ILocalWorkflowRunner:
+        """Returns the runner at the given site."""
         self._registry_replica.update()
         for o in self._registry_replica.objects:
             if isinstance(o, SiteDescription):
-                if o.runner is not None:
-                    if o.runner.name == runner_name:
+                if o.name == site_name:
+                    if o.runner is not None:
                         return o.runner
-        raise RuntimeError(f'Runner {runner_name} not found')
+        raise RuntimeError(f'Runner at site {site_name} not found')
 
     def _get_store(self, site_name: str) -> IAssetStore:
         """Returns the store with the given name."""

--- a/proof_of_concept/ddm_site.py
+++ b/proof_of_concept/ddm_site.py
@@ -8,6 +8,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from proof_of_concept.asset import Asset
 from proof_of_concept.asset_store import AssetStore
 from proof_of_concept.ddm_client import DDMClient
+from proof_of_concept.definitions import PartyDescription
 from proof_of_concept.local_workflow_runner import LocalWorkflowRunner
 from proof_of_concept.policy import PolicyEvaluator, Rule
 from proof_of_concept.policy_replication import PolicySource
@@ -55,8 +56,8 @@ class Site:
                 backend=default_backend())
 
         self._ddm_client.register_party(
-                self.administrator,
-                self._private_key.public_key())
+                PartyDescription(
+                    self.administrator, self._private_key.public_key()))
 
         # Policy support
         self._policy_archive = ReplicableArchive[Rule]()

--- a/proof_of_concept/ddm_site.py
+++ b/proof_of_concept/ddm_site.py
@@ -72,7 +72,7 @@ class Site:
         self.store = AssetStore(self._policy_evaluator)
 
         self.runner = LocalWorkflowRunner(
-                name + '-runner', self.administrator,
+                name + '-site', self.administrator,
                 self._policy_evaluator, self.store)
 
         # Client side

--- a/proof_of_concept/ddm_site.py
+++ b/proof_of_concept/ddm_site.py
@@ -40,6 +40,9 @@ class Site:
         # Metadata
         self.name = name
         self.owner = owner
+        # Owner and administrator are the same for now, but could
+        # in principle be different, e.g. in a SaaS scenario. They also
+        # differ semantically, so we have both here to make that clear.
         self.administrator = owner
         self.namespace = namespace
 

--- a/proof_of_concept/ddm_site.py
+++ b/proof_of_concept/ddm_site.py
@@ -72,7 +72,7 @@ class Site:
         self.store = AssetStore(self._policy_evaluator)
 
         self.runner = LocalWorkflowRunner(
-                name + '-site', self.administrator,
+                name, self.administrator,
                 self._policy_evaluator, self.store)
 
         # Client side
@@ -81,13 +81,13 @@ class Site:
 
         # Register site with DDM
         self._ddm_client.register_site(
-                self.name + '-site', self.owner, self.administrator,
+                self.name, self.owner, self.administrator,
                 self.runner, self.store, self.namespace, self.policy_server)
 
         # Insert data
         for asset in stored_data:
             self.store.store(asset)
-            self._ddm_client.register_asset(asset.id, self.name + '-site')
+            self._ddm_client.register_asset(asset.id, self.name)
 
     def __repr__(self) -> str:
         """Return a string representation of this object."""

--- a/proof_of_concept/ddm_site.py
+++ b/proof_of_concept/ddm_site.py
@@ -69,10 +69,7 @@ class Site:
         self._policy_evaluator = PolicyEvaluator(self._policy_source)
 
         # Server side
-        self.store = AssetStore(name + '-store', self._policy_evaluator)
-        for asset in stored_data:
-            self.store.store(asset)
-            self._ddm_client.register_asset(asset.id, self.store.name)
+        self.store = AssetStore(self._policy_evaluator)
 
         self.runner = LocalWorkflowRunner(
                 name + '-runner', self.administrator,
@@ -86,6 +83,11 @@ class Site:
         self._ddm_client.register_site(
                 self.name + '-site', self.owner, self.administrator,
                 self.runner, self.store, self.namespace, self.policy_server)
+
+        # Insert data
+        for asset in stored_data:
+            self.store.store(asset)
+            self._ddm_client.register_asset(asset.id, self.name + '-site')
 
     def __repr__(self) -> str:
         """Return a string representation of this object."""

--- a/proof_of_concept/ddm_site.py
+++ b/proof_of_concept/ddm_site.py
@@ -8,7 +8,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from proof_of_concept.asset import Asset
 from proof_of_concept.asset_store import AssetStore
 from proof_of_concept.ddm_client import DDMClient
-from proof_of_concept.definitions import PartyDescription
+from proof_of_concept.definitions import PartyDescription, SiteDescription
 from proof_of_concept.local_workflow_runner import LocalWorkflowRunner
 from proof_of_concept.policy import PolicyEvaluator, Rule
 from proof_of_concept.policy_replication import PolicySource
@@ -85,8 +85,10 @@ class Site:
 
         # Register site with DDM
         self._ddm_client.register_site(
-                self.name, self.owner, self.administrator,
-                self.runner, self.store, self.namespace, self.policy_server)
+                SiteDescription(
+                    self.name, self.owner, self.administrator,
+                    self.runner, self.store, self.namespace,
+                    self.policy_server))
 
         # Insert data
         for asset in stored_data:

--- a/proof_of_concept/definitions.py
+++ b/proof_of_concept/definitions.py
@@ -14,32 +14,32 @@ class Plan:
     which site), and where the inputs should be obtained from.
 
     Attributes:
-        input_stores (Dict[str, str]): Maps inputs to the store to
+        input_sites (Dict[str, str]): Maps inputs to the site to
                 obtain them from.
         step_runners (Dict[WorkflowStep, str]): Maps steps to their
                 runner's id.
 
     """
     def __init__(
-            self, input_stores: Dict[str, str],
+            self, input_sites: Dict[str, str],
             step_runners: Dict[WorkflowStep, str]
             ) -> None:
         """Create a plan.
 
         Args:
-            input_stores: A map from input names to a store id to get
+            input_sites: A map from input names to a site id to get
                     them from.
             step_runners: A map from steps to their runner's id.
 
         """
-        self.input_stores = input_stores
+        self.input_sites = input_sites
         self.step_runners = step_runners
 
     def __str__(self) -> str:
         """Return a string representation of the object."""
         result = ''
-        for inp_name, store_id in self.input_stores.items():
-            result += '{} <- {}\n'.format(inp_name, store_id)
+        for inp_name, site_id in self.input_sites.items():
+            result += '{} <- {}\n'.format(inp_name, site_id)
         for step, runner_id in self.step_runners.items():
             result += '{} -> {}\n'.format(step.name, runner_id)
         return result
@@ -47,7 +47,6 @@ class Plan:
 
 class IAssetStore:
     """An interface for asset stores."""
-    name = None     # type: str
 
     def store(self, asset: Asset) -> None:
         """Stores an asset.
@@ -82,15 +81,6 @@ class IAssetStore:
 class ILocalWorkflowRunner:
     """Interface for services for running workflows at a given site."""
     name = None     # type: str
-
-    def target_store(self) -> str:
-        """Returns the name of the store containing our results.
-
-        Returns:
-            A string with the name.
-
-        """
-        raise NotImplementedError()
 
     def execute_job(
             self,

--- a/proof_of_concept/definitions.py
+++ b/proof_of_concept/definitions.py
@@ -1,7 +1,7 @@
 """Some global definitions."""
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
-from typing import Dict
+from typing import Dict, Optional
 
 from proof_of_concept.asset import Asset
 from proof_of_concept.policy import Rule
@@ -120,3 +120,57 @@ class PartyDescription:
         """
         self.name = name
         self.public_key = public_key
+
+
+class SiteDescription:
+    """Describes a site to the rest of the DDM.
+
+    Attributes:
+        name: Name of the site.
+        owner_name: Name of the party which owns this site.
+        admin_name: Name of the party which administrates this site.
+        runner: This site's local workflow runner.
+        store: This site's asset store.
+        namespace: The namespace managed by this site's policy server.
+        policy_server: This site's policy server.
+
+    """
+    def __init__(
+            self,
+            name: str,
+            owner_name: str,
+            admin_name: str,
+            runner: Optional[ILocalWorkflowRunner],
+            store: Optional[IAssetStore],
+            namespace: Optional[str],
+            policy_server: Optional[IPolicyServer]
+            ) -> None:
+        """Create a SiteDescription.
+
+        Args:
+            name: Name of the site.
+            owner_name: Name of the party which owns this site.
+            admin_name: Name of the party which administrates this site.
+            runner: This site's local workflow runner.
+            store: This site's asset store.
+            namespace: The namespace managed by this site's policy
+                server.
+            policy_server: This site's policy server.
+
+        """
+        self.name = name
+        self.owner_name = owner_name
+        self.admin_name = admin_name
+        self.runner = runner
+        self.store = store
+        self.namespace = namespace
+        self.policy_server = policy_server
+
+        if store is None and runner is not None:
+            raise RuntimeError('Site with runner needs a store')
+
+        if namespace is None and policy_server is not None:
+            raise RuntimeError('Policy server specified without namespace')
+
+        if namespace is not None and policy_server is None:
+            raise RuntimeError('Namespace specified but policy server missing')

--- a/proof_of_concept/definitions.py
+++ b/proof_of_concept/definitions.py
@@ -10,38 +10,38 @@ from proof_of_concept.workflow import Job, WorkflowStep
 class Plan:
     """A plan for executing a workflow.
 
-    A plan says which step is to be executed by which runner (i.e. at
-    which site), and where the inputs should be obtained from.
+    A plan says which step is to be executed by which site, and where
+    the inputs should be obtained from.
 
     Attributes:
         input_sites (Dict[str, str]): Maps inputs to the site to
                 obtain them from.
-        step_runners (Dict[WorkflowStep, str]): Maps steps to their
-                runner's id.
+        step_sites (Dict[WorkflowStep, str]): Maps steps to their
+                site's id.
 
     """
     def __init__(
             self, input_sites: Dict[str, str],
-            step_runners: Dict[WorkflowStep, str]
+            step_sites: Dict[WorkflowStep, str]
             ) -> None:
         """Create a plan.
 
         Args:
             input_sites: A map from input names to a site id to get
                     them from.
-            step_runners: A map from steps to their runner's id.
+            step_sites: A map from steps to their site's id.
 
         """
         self.input_sites = input_sites
-        self.step_runners = step_runners
+        self.step_sites = step_sites
 
     def __str__(self) -> str:
         """Return a string representation of the object."""
         result = ''
         for inp_name, site_id in self.input_sites.items():
             result += '{} <- {}\n'.format(inp_name, site_id)
-        for step, runner_id in self.step_runners.items():
-            result += '{} -> {}\n'.format(step.name, runner_id)
+        for step, site_id in self.step_sites.items():
+            result += '{} -> {}\n'.format(step.name, site_id)
         return result
 
 
@@ -80,7 +80,6 @@ class IAssetStore:
 
 class ILocalWorkflowRunner:
     """Interface for services for running workflows at a given site."""
-    name = None     # type: str
 
     def execute_job(
             self,

--- a/proof_of_concept/definitions.py
+++ b/proof_of_concept/definitions.py
@@ -1,4 +1,6 @@
 """Some global definitions."""
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+
 from typing import Dict
 
 from proof_of_concept.asset import Asset
@@ -99,3 +101,22 @@ class ILocalWorkflowRunner:
 
 
 IPolicyServer = IReplicationServer[Rule]
+
+
+class PartyDescription:
+    """Describes a Party to the rest of the DDM.
+
+    Attributes:
+        name: Name of the party.
+        public_key: The party's public key for signing rules.
+
+    """
+    def __init__(self, name: str, public_key: RSAPublicKey) -> None:
+        """Create a PartyDescription.
+
+        Args:
+            name: Name of the party.
+            public_key: The party's public key for signing rules.
+        """
+        self.name = name
+        self.public_key = public_key

--- a/proof_of_concept/local_workflow_runner.py
+++ b/proof_of_concept/local_workflow_runner.py
@@ -185,8 +185,8 @@ class JobRun(Thread):
         return step_input_data
 
     def _retrieve_compute_asset(self, compute_asset_id: str) -> ComputeAsset:
-        site_id = self._ddm_client.get_asset_location(compute_asset_id)
-        asset = self._ddm_client.retrieve_asset(site_id=site_id,
+        site_name = self._ddm_client.get_asset_location(compute_asset_id)
+        asset = self._ddm_client.retrieve_asset(site_name=site_name,
                                                 asset_id=compute_asset_id)
         if not isinstance(asset, ComputeAsset):
             raise TypeError('Expecting a compute asset in workflow')

--- a/proof_of_concept/registry.py
+++ b/proof_of_concept/registry.py
@@ -82,6 +82,9 @@ class SiteDescription(RegisteredObject):
         self.namespace = namespace
         self.policy_server = policy_server
 
+        if store is None and runner is not None:
+            raise RuntimeError('Site with runner needs a store')
+
         if namespace is None and policy_server is not None:
             raise RuntimeError('Policy server specified without namespace')
 
@@ -160,25 +163,25 @@ class Registry:
                 name, owner, admin, runner, store, namespace, policy_server)
         self._store.insert(site_desc)
 
-    def register_asset(self, asset_id: str, store_name: str) -> None:
+    def register_asset(self, asset_id: str, site_name: str) -> None:
         """Register an Asset with the Registry.
 
         Args:
             asset_id: The id of the asset to register.
-            store_name: Name of the store where it can be found.
+            site_name: Name of the site where it can be found.
         """
         if asset_id in self._asset_locations:
             raise RuntimeError('There is already an asset with this name')
-        self._asset_locations[asset_id] = store_name
+        self._asset_locations[asset_id] = site_name
 
     def get_asset_location(self, asset_id: str) -> str:
-        """Returns the name of the store this asset is in.
+        """Returns the name of the site this asset is in.
 
         Args:
             asset_id: ID of the asset to find.
 
         Return:
-            The store it can be found in.
+            The site it can be found at.
 
         Raises:
             KeyError: If no asset with the given id is registered.

--- a/proof_of_concept/registry.py
+++ b/proof_of_concept/registry.py
@@ -4,28 +4,9 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from proof_of_concept.definitions import (
-        IAssetStore, ILocalWorkflowRunner, IPolicyServer)
+        IAssetStore, ILocalWorkflowRunner, IPolicyServer, PartyDescription)
 from proof_of_concept.replication import (
         CanonicalStore, ReplicableArchive, ReplicationServer)
-
-
-class PartyDescription:
-    """Describes a Party to the rest of the DDM.
-
-    Attributes:
-        name: Name of the party.
-        public_key: The party's public key for signing rules.
-
-    """
-    def __init__(self, name: str, public_key: RSAPublicKey) -> None:
-        """Create a PartyDescription.
-
-        Args:
-            name: Name of the party.
-            public_key: The party's public key for signing rules.
-        """
-        self.name = name
-        self.public_key = public_key
 
 
 class SiteDescription:
@@ -105,18 +86,17 @@ class Registry:
                 archive, 1.0)
 
     def register_party(
-            self, name: str, public_key: RSAPublicKey) -> None:
+            self, description: PartyDescription) -> None:
         """Register a party with the DDM.
 
         Args:
-            name: Name of the party.
-            public_key: Public key of this party.
+            description: A description of the party
         """
-        if self._in_store(PartyDescription, 'name', name):
-            raise RuntimeError(f'There is already a party called {name}')
+        if self._in_store(PartyDescription, 'name', description.name):
+            raise RuntimeError(
+                    f'There is already a party called {description.name}')
 
-        party_desc = PartyDescription(name, public_key)
-        self._store.insert(party_desc)
+        self._store.insert(description)
 
     def register_site(
             self,

--- a/proof_of_concept/registry.py
+++ b/proof_of_concept/registry.py
@@ -1,5 +1,5 @@
 """Central registry of remote-accessible things."""
-from typing import Any, Dict, List, Optional, Set, Tuple, Type, TypeVar
+from typing import Any, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
@@ -9,17 +9,7 @@ from proof_of_concept.replication import (
         CanonicalStore, ReplicableArchive, ReplicationServer)
 
 
-class RegisteredObject:
-    """A parent class for DDM-wide metadata classes.
-
-    This is here mainly because it's required for the replication
-    system.
-
-    """
-    pass
-
-
-class PartyDescription(RegisteredObject):
+class PartyDescription:
     """Describes a Party to the rest of the DDM.
 
     Attributes:
@@ -38,7 +28,7 @@ class PartyDescription(RegisteredObject):
         self.public_key = public_key
 
 
-class SiteDescription(RegisteredObject):
+class SiteDescription:
     """Describes a site to the rest of the DDM.
 
     Attributes:
@@ -90,6 +80,9 @@ class SiteDescription(RegisteredObject):
 
         if namespace is not None and policy_server is None:
             raise RuntimeError('Namespace specified but policy server missing')
+
+
+RegisteredObject = Union[PartyDescription, SiteDescription]
 
 
 _ReplicatedClass = TypeVar('_ReplicatedClass', bound=RegisteredObject)

--- a/proof_of_concept/workflow_engine.py
+++ b/proof_of_concept/workflow_engine.py
@@ -98,11 +98,11 @@ class WorkflowPlanner:
 
         step_runners = [dict(zip(sorted_steps, plan)) for plan in plan_from(0)]
         # We'll have some other kind of resolver here later
-        input_stores = {
+        input_sites = {
                 inp: self._ddm_client.get_asset_location(inp)
                 for inp in job.inputs.values()}
 
-        return [Plan(input_stores, runners) for runners in step_runners]
+        return [Plan(input_sites, runners) for runners in step_runners]
 
     def _sort_workflow(self, workflow: Workflow) -> List[WorkflowStep]:
         """Sorts the workflow's steps topologically.
@@ -169,12 +169,12 @@ class WorkflowExecutor:
                     src_step_name, src_step_output = wf_outp_source.split('.')
                     src_runner_name = plan.step_runners[
                             wf.steps[src_step_name]]
-                    src_store = self._ddm_client.get_target_store(
+                    src_site = self._ddm_client.get_target_site(
                             src_runner_name)
                     outp_key = keys[wf_outp_name]
                     try:
                         asset = self._ddm_client.retrieve_asset(
-                                    src_store, outp_key)
+                                    src_site, outp_key)
                         results[wf_outp_name] = asset.data
                     except KeyError:
                         continue

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__file__)
 
 def run_scenario(scenario: Dict[str, Any]) -> Dict[str, Any]:
     logger.info('Running test scenario '
-                'on behalf of: {}'.format(scenario['user_site'].administrator))
+                'on behalf of: {}'.format(scenario['user_site'].owner))
     logger.info(f'Job:\n'
                 f'{indent(str(scenario["job"]), " "*4)}')
 
@@ -100,13 +100,13 @@ def test_pii(clean_global_registry):
             ]
 
     scenario['sites'] = [
-            Site(name='site1', administrator='party1', namespace='party1_ns',
+            Site(name='site1', owner='party1', namespace='party1_ns',
                  stored_data=[DataAsset('id:party1_ns/dataset/pii1', 42)],
                  rules=scenario['rules-party1']),
-            Site(name='site2', administrator='party2', namespace='party2_ns',
+            Site(name='site2', owner='party2', namespace='party2_ns',
                  stored_data=[DataAsset('id:party2_ns/dataset/pii2', 3)],
                  rules=scenario['rules-party2']),
-            Site(name='site3', administrator='ddm', namespace='ddm_ns',
+            Site(name='site3', owner='ddm', namespace='ddm_ns',
                  stored_data=[
                      ComputeAsset('id:ddm_ns/software/combine', None, None),
                      ComputeAsset('id:ddm_ns/software/anonymise', None, None),

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -21,8 +21,8 @@ class MockPolicySource:
 def test_wf_output_checks():
     """Check whether workflow output permissions are checked."""
     mock_client = MagicMock()
-    mock_client.list_runners = MagicMock(return_value=['s1', 's2'])
-    mock_client.get_runner_administrator = lambda x: (
+    mock_client.list_sites_with_runners = MagicMock(return_value=['s1', 's2'])
+    mock_client.get_site_administrator = lambda x: (
             'p1' if x == 's1' else 'p2')
     mock_client.get_asset_location = lambda x: (
             's1' if 'p1' in x else 's2')
@@ -60,8 +60,8 @@ def test_wf_output_checks():
     plans = planner.make_plans('p2', job)
     assert len(plans) == 1
     assert plans[0].input_sites['id:p1/dataset/d1'] == 's1'
-    assert plans[0].step_runners[workflow.steps['anonymise']] == 's1'
-    assert plans[0].step_runners[workflow.steps['aggregate']] == 's1'
+    assert plans[0].step_sites[workflow.steps['anonymise']] == 's1'
+    assert plans[0].step_sites[workflow.steps['aggregate']] == 's1'
 
     # test output from intermediate step
     workflow.outputs['y'] = 'anonymise.y'

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -25,7 +25,7 @@ def test_wf_output_checks():
     mock_client.get_runner_administrator = lambda x: (
             'p1' if x == 's1' else 'p2')
     mock_client.get_asset_location = lambda x: (
-            's1-store' if 'p1' in x else 's2-store')
+            's1' if 'p1' in x else 's2')
 
     rules = [
             MayAccess('p1', 'Anonymise'),
@@ -59,7 +59,7 @@ def test_wf_output_checks():
     planner = WorkflowPlanner(mock_client, policy_evaluator)
     plans = planner.make_plans('p2', job)
     assert len(plans) == 1
-    assert plans[0].input_stores['id:p1/dataset/d1'] == 's1-store'
+    assert plans[0].input_sites['id:p1/dataset/d1'] == 's1'
     assert plans[0].step_runners[workflow.steps['anonymise']] == 's1'
     assert plans[0].step_runners[workflow.steps['aggregate']] == 's1'
 


### PR DESCRIPTION
This modifies the Registry to register sites, with optional runners, asset stores and policy servers, rather than registering those components individually. The idea is that this lets us have a single REST endpoint per site, rather than three, which simplifies things like firewalls and packaging, but comes at the cost of having an API with optional bits. I think that that's a good trade-off, so here we are.