### PR TITLE
Issue 28: Factor PolicyServer replicas out of DDMClient

### DIFF
--- a/proof_of_concept/ddm_client.py
+++ b/proof_of_concept/ddm_client.py
@@ -71,14 +71,17 @@ class RuleValidator(ObjectValidator[Rule]):
 
 class DDMClient:
     """Handles connecting to global registry, runners and stores."""
-    def __init__(self, site: str) -> None:
+    def __init__(self, site: str, site_validator: Validator) -> None:
         """Create a DDMClient.
 
         Args:
             site: The site at which this client acts.
+            site_validator: A validator for the Site REST API.
 
         """
         self._site = site
+        self._site_validator = site_validator
+
         # TODO: This will be passed in as an argument later.
         self._registry_endpoint = 'http://localhost:4413'
 
@@ -96,12 +99,6 @@ class DDMClient:
                 registry_client, on_update=self._on_registry_update)
 
         # Set up connections to sites
-        site_api_file = Path(__file__).parent / 'site_api.yaml'
-        with open(site_api_file, 'r') as f:
-            site_api_def = yaml.safe_load(f.read())
-
-        self._site_validator = Validator(site_api_def)
-
         self._policy_replicas = dict()  # type: Dict[str, Replica[Rule]]
 
         # Get initial data

--- a/proof_of_concept/ddm_client.py
+++ b/proof_of_concept/ddm_client.py
@@ -126,6 +126,15 @@ class DDMClient:
         self._callbacks.append(callback)
         callback(self._registry_replica.objects, set())
 
+    def update(self) -> None:
+        """Ensures the local registry information is up-to-date.
+
+        If the registry is updated, this will call any registered
+        callback functions with the changes.
+
+        """
+        self._registry_replica.update()
+
     def register_party(self, description: PartyDescription) -> None:
         """Register a party with the Registry.
 
@@ -197,7 +206,7 @@ class DDMClient:
             A dict mapping namespaces to their governing rules.
 
         """
-        self._registry_replica.update()
+        self.update()
         for replica in self._policy_replicas.values():
             replica.update()
         result = {
@@ -207,7 +216,7 @@ class DDMClient:
 
     def list_sites_with_runners(self) -> List[str]:
         """Returns a list of id's of sites with runners."""
-        self._registry_replica.update()
+        self.update()
         sites = list()    # type: List[str]
         for o in self._registry_replica.objects:
             if isinstance(o, SiteDescription):
@@ -256,7 +265,7 @@ class DDMClient:
 
     def _get_party(self, name: str) -> Optional[PartyDescription]:
         """Returns the party with the given name."""
-        self._registry_replica.update()
+        self.update()
         for o in self._registry_replica.objects:
             if isinstance(o, PartyDescription):
                 if o.name == name:
@@ -266,7 +275,7 @@ class DDMClient:
     def _get_site(
             self, attr_name: str, value: Any) -> Optional[SiteDescription]:
         """Returns a site with a given attribute value."""
-        self._registry_replica.update()
+        self.update()
         for o in self._registry_replica.objects:
             if isinstance(o, SiteDescription):
                 a = getattr(o, attr_name)

--- a/proof_of_concept/ddm_site.py
+++ b/proof_of_concept/ddm_site.py
@@ -79,7 +79,8 @@ class Site:
             self._policy_store.insert(rule)
         self.policy_server = PolicyServer(self._policy_archive, 0.1)
 
-        self._policy_source = PolicySource(self._ddm_client)
+        self._policy_source = PolicySource(
+                self._ddm_client, self._site_validator)
         self._policy_evaluator = PolicyEvaluator(self._policy_source)
 
         # Server side

--- a/proof_of_concept/ddm_site.py
+++ b/proof_of_concept/ddm_site.py
@@ -1,9 +1,11 @@
 """This module combines components into a site installation."""
 import logging
+from pathlib import Path
 from typing import Any, Dict, List
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
+import ruamel.yaml as yaml
 
 from proof_of_concept.asset import Asset
 from proof_of_concept.asset_store import AssetStore
@@ -14,6 +16,7 @@ from proof_of_concept.local_workflow_runner import LocalWorkflowRunner
 from proof_of_concept.policy import PolicyEvaluator, Rule
 from proof_of_concept.policy_replication import PolicyServer, PolicySource
 from proof_of_concept.replication import CanonicalStore, ReplicableArchive
+from proof_of_concept.validation import Validator
 from proof_of_concept.workflow import Job
 from proof_of_concept.workflow_engine import GlobalWorkflowRunner
 
@@ -48,7 +51,15 @@ class Site:
         self.administrator = owner
         self.namespace = namespace
 
-        self._ddm_client = DDMClient(self.name)
+        # Load API definitions
+        site_api_file = Path(__file__).parent / 'site_api.yaml'
+        with open(site_api_file, 'r') as f:
+            site_api_def = yaml.safe_load(f.read())
+
+        self._site_validator = Validator(site_api_def)
+
+        # Create client for talking to other sites
+        self._ddm_client = DDMClient(self.name, self._site_validator)
 
         # Register party with DDM
         self._private_key = rsa.generate_private_key(

--- a/proof_of_concept/ddm_site.py
+++ b/proof_of_concept/ddm_site.py
@@ -79,8 +79,7 @@ class Site:
             self._policy_store.insert(rule)
         self.policy_server = PolicyServer(self._policy_archive, 0.1)
 
-        self._policy_source = PolicySource(
-                self._ddm_client, self._policy_store)
+        self._policy_source = PolicySource(self._ddm_client)
         self._policy_evaluator = PolicyEvaluator(self._policy_source)
 
         # Server side

--- a/proof_of_concept/policy_replication.py
+++ b/proof_of_concept/policy_replication.py
@@ -1,39 +1,116 @@
 """Classes for distributing policies around the DDM."""
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Set
 
 from proof_of_concept.ddm_client import DDMClient
-from proof_of_concept.definitions import PolicyUpdate
+from proof_of_concept.definitions import (
+        PolicyUpdate, RegisteredObject, SiteDescription)
 from proof_of_concept.policy import (
         IPolicySource, InPartyCollection, InAssetCollection, MayAccess,
         ResultOfDataIn, ResultOfComputeIn, Rule)
 from proof_of_concept.replication import (
-        CanonicalStore, IReplicationSource, ObjectValidator, Replica,
-        ReplicationServer)
+        ObjectValidator, Replica, ReplicationServer)
+from proof_of_concept.replication_rest import ReplicationClient
+from proof_of_concept.validation import Validator
 
 
-# Defining this where it's used makes mypy crash.
-# See https://github.com/python/mypy/issues/7281
-_OtherStores = Dict[IReplicationSource[Rule], Replica[Rule]]
+class PolicyClient(ReplicationClient[Rule]):
+    """A client for policy servers."""
+    UpdateType = PolicyUpdate
+
+
+class RuleValidator(ObjectValidator[Rule]):
+    """Validates incoming policy rules by checking signatures."""
+    def __init__(self, ddm_client: DDMClient, namespace: str) -> None:
+        """Create a RuleValidator.
+
+        Checks that rules apply to the given namespace, and that they
+        have been signed by the owner of that namespace.
+
+        Args:
+            ddm_client: A DDMClient to use.
+            namespace: The namespace to expect rules for.
+        """
+        self._key = ddm_client.get_public_key_for_ns(namespace)
+        self._namespace = namespace
+
+    def is_valid(self, rule: Rule) -> bool:
+        """Return True iff the rule is properly signed."""
+        if isinstance(rule, ResultOfDataIn):
+            namespace = rule.data_asset[3:].split('.')[0]
+        elif isinstance(rule, ResultOfComputeIn):
+            namespace = rule.compute_asset[3:].split('.')[0]
+        elif isinstance(rule, MayAccess):
+            namespace = rule.asset[3:].split('.')[0]
+        elif isinstance(rule, InAssetCollection):
+            namespace = rule.asset[3:].split('.')[0]
+        elif isinstance(rule, InPartyCollection):
+            namespace = rule.collection[3:].split('.')[0]
+
+        if namespace != self._namespace:
+            return False
+        return rule.has_valid_signature(self._key)
 
 
 class PolicySource(IPolicySource):
     """Ties together various sources of policies."""
-    def __init__(self, ddm_client: DDMClient) -> None:
+    def __init__(
+            self, ddm_client: DDMClient, site_validator: Validator) -> None:
         """Create a PolicySource.
 
         This will automatically keep the replicas up-to-date as needed.
 
         Args:
             ddm_client: A DDMClient to use for getting servers.
+            site_validator: A REST Validator for the Site API.
         """
         self._ddm_client = ddm_client
+        self._site_validator = site_validator
+
+        self._policy_replicas = dict()  # type: Dict[str, Replica[Rule]]
+        self._ddm_client.register_callback(self.on_update)
 
     def policies(self) -> Iterable[Rule]:
         """Returns the collected rules."""
-        rules = list()      # type: List[Rule]
-        for site_rules in self._ddm_client.get_rules().values():
-            rules.extend(site_rules)
-        return rules
+        self._update()
+        return [
+                rule
+                for replica in self._policy_replicas.values()
+                for rule in replica.objects]
+
+    def on_update(
+            self, created: Set[RegisteredObject],
+            deleted: Set[RegisteredObject]
+            ) -> None:
+        """Called when sites and/or parties appear or disappear.
+
+        This is called by the DDMClient whenever there's a change in
+        the local registry replica. In response, we update our list
+        of policy replicas to match the new and removed sites.
+
+        Args:
+            created: Set of new objects.
+            deleted: Set of removed objects.
+        """
+        for o in created:
+            if isinstance(o, SiteDescription) and o.namespace:
+                client = PolicyClient(
+                        o.endpoint + '/rules/updates', self._site_validator)
+
+                validator = RuleValidator(self._ddm_client, o.namespace)
+                self._policy_replicas[o.namespace] = Replica[Rule](
+                        client, validator)
+
+        for o in deleted:
+            if isinstance(o, SiteDescription) and o.namespace:
+                del(self._policy_replicas[o.namespace])
+
+    def _update(self) -> None:
+        """Ensures policy replicas are up to date."""
+        self._ddm_client.update()
+        # The above calls back on_update(), which adds and removes
+        # replicas as needed, so now we just need to update them.
+        for replica in self._policy_replicas.values():
+            replica.update()
 
 
 class PolicyServer(ReplicationServer[Rule]):

--- a/proof_of_concept/policy_replication.py
+++ b/proof_of_concept/policy_replication.py
@@ -18,23 +18,18 @@ _OtherStores = Dict[IReplicationSource[Rule], Replica[Rule]]
 
 class PolicySource(IPolicySource):
     """Ties together various sources of policies."""
-    def __init__(
-            self, ddm_client: DDMClient, our_store: CanonicalStore[Rule]
-            ) -> None:
+    def __init__(self, ddm_client: DDMClient) -> None:
         """Create a PolicySource.
 
         This will automatically keep the replicas up-to-date as needed.
 
         Args:
             ddm_client: A DDMClient to use for getting servers.
-            our_store: A store containing our policies.
         """
         self._ddm_client = ddm_client
-        self._our_store = our_store
 
     def policies(self) -> Iterable[Rule]:
         """Returns the collected rules."""
-        # rules = list(self._our_store.objects())
         rules = list()      # type: List[Rule]
         for site_rules in self._ddm_client.get_rules().values():
             rules.extend(site_rules)


### PR DESCRIPTION
This implements #28. There's a slight change relative to the plan, because we were getting a chicken-and-egg problem with registering handlers, so now there's a `DDMClient.register_callback()` instead of passing it to the init.