### PR TITLE
Split DDMClient into RegistryClient and PeerClient

### DIFF
--- a/proof_of_concept/ddm_client.py
+++ b/proof_of_concept/ddm_client.py
@@ -22,7 +22,7 @@ from proof_of_concept.validation import Validator
 from proof_of_concept.workflow import Job, Workflow
 
 
-class RegistryClient(ReplicationClient[RegisteredObject]):
+class RegistryRestClient(ReplicationClient[RegisteredObject]):
     """A client for the registry."""
     UpdateType = RegistryUpdate
 
@@ -56,7 +56,7 @@ class DDMClient:
 
         registry_validator = Validator(registry_api_def)
 
-        registry_client = RegistryClient(
+        registry_client = RegistryRestClient(
                 self._registry_endpoint + '/updates', registry_validator)
 
         self._registry_replica = Replica[RegisteredObject](

--- a/proof_of_concept/ddm_client.py
+++ b/proof_of_concept/ddm_client.py
@@ -31,6 +31,11 @@ RegistryCallback = Callable[
         [Set[RegisteredObject], Set[RegisteredObject]], None]
 
 
+class RegistryReplica(Replica[RegisteredObject]):
+    """Local replica of the global registry."""
+    pass
+
+
 class DDMClient:
     """Handles connecting to global registry, runners and stores."""
     def __init__(self, site: str, site_validator: Validator) -> None:
@@ -59,7 +64,7 @@ class DDMClient:
         registry_client = RegistryRestClient(
                 self._registry_endpoint + '/updates', registry_validator)
 
-        self._registry_replica = Replica[RegisteredObject](
+        self._registry_replica = RegistryReplica(
                 registry_client, on_update=self._on_registry_update)
 
         # Get initial data


### PR DESCRIPTION
This one is designed to apply on top of #36, so that needs to be merged first. This splits DDMClient into two classes, RegistryClient does registration with the global registry and contains a replica of same, while PeerClient is for connecting to other sites to submit jobs and retrieve assets. For now, RegistryClient also still contains the asset registration code, but that will be removed when the new Asset IDs are implemented (#18).

Closes #29.