### PR TITLE
Clean up Server/Client/Api/Source terminology

### DIFF
--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -1,0 +1,28 @@
+===========
+Terminology
+===========
+
+This proof-of-concept contains quite a few classes which play different roles in
+the system. They're named systematically, so that we have some hope of being
+able to see what is what. Here's a key to class names:
+
+...Service
+  A service is a class which offers a service to other sites. Its interface is
+  in Python, this is not a REST service or network service.
+
+...Client
+  Manages a local replica of a remote canonical store, like the registry or the
+  policy stores at other sites.
+
+...Handler
+  A class which handles a specific type of REST request.
+
+...RestApi
+  Represents a REST API. Contains Handlers, can be served using a Server, and
+  contains an App object which can be used when running in a UWSGI server.
+
+...Server
+  A simple HTTP server for serving Apis in the test environment.
+
+...RestClient
+  Used to connect to a Server serving a RestApi.

--- a/proof_of_concept/ddm_client.py
+++ b/proof_of_concept/ddm_client.py
@@ -9,7 +9,7 @@ import ruamel.yaml as yaml
 
 from proof_of_concept.asset import Asset
 from proof_of_concept.definitions import (
-        IAssetStore, IPolicyServer, JobSubmission,
+        IAssetStore, JobSubmission,
         PartyDescription, PolicyUpdate, RegistryUpdate, SiteDescription)
 from proof_of_concept.policy import (
         InAssetCollection, InPartyCollection, MayAccess, ResultOfComputeIn,

--- a/proof_of_concept/ddm_client.py
+++ b/proof_of_concept/ddm_client.py
@@ -17,12 +17,12 @@ from proof_of_concept.policy import (
 from proof_of_concept.serialization import deserialize, serialize
 from proof_of_concept.registry import global_registry, RegisteredObject
 from proof_of_concept.replication import ObjectValidator, Replica
-from proof_of_concept.replication_rest import ReplicationClient
+from proof_of_concept.replication_rest import ReplicationRestClient
 from proof_of_concept.validation import Validator
 from proof_of_concept.workflow import Job, Workflow
 
 
-class RegistryRestClient(ReplicationClient[RegisteredObject]):
+class RegistryRestClient(ReplicationRestClient[RegisteredObject]):
     """A client for the registry."""
     UpdateType = RegistryUpdate
 

--- a/proof_of_concept/ddm_client.py
+++ b/proof_of_concept/ddm_client.py
@@ -217,7 +217,7 @@ class PeerClient:
             self, site: str, site_validator: Validator,
             registry_client: RegistryClient
             ) -> None:
-        """Create a DDMClient.
+        """Create a PeerClient.
 
         Args:
             site: The site at which this client acts.

--- a/proof_of_concept/ddm_client.py
+++ b/proof_of_concept/ddm_client.py
@@ -211,13 +211,13 @@ class RegistryClient:
             callback(created, deleted)
 
 
-class PeerClient:
+class SiteRestClient:
     """Handles connecting to other sites' runners and stores."""
     def __init__(
             self, site: str, site_validator: Validator,
             registry_client: RegistryClient
             ) -> None:
-        """Create a PeerClient.
+        """Create a SiteRestClient.
 
         Args:
             site: The site at which this client acts.

--- a/proof_of_concept/ddm_site.py
+++ b/proof_of_concept/ddm_site.py
@@ -60,7 +60,7 @@ class Site:
 
         # Create clients for talking to the DDM
         self._registry_client = RegistryClient()
-        self._peer_client = SiteRestClient(
+        self._site_rest_client = SiteRestClient(
                 self.name, self._site_validator, self._registry_client)
 
         # Register party with DDM

--- a/proof_of_concept/ddm_site.py
+++ b/proof_of_concept/ddm_site.py
@@ -10,7 +10,7 @@ import ruamel.yaml as yaml
 from proof_of_concept.asset import Asset
 from proof_of_concept.asset_store import AssetStore
 from proof_of_concept.ddm_client import PeerClient, RegistryClient
-from proof_of_concept.ddm_site_api import SiteApi, SiteServer
+from proof_of_concept.ddm_site_api import SiteRestApi, SiteServer
 from proof_of_concept.definitions import PartyDescription, SiteDescription
 from proof_of_concept.step_runner import StepRunner
 from proof_of_concept.policy import PolicyEvaluator, Rule
@@ -92,7 +92,7 @@ class Site:
                 self._policy_evaluator, self.store)
 
         # REST server
-        self.api = SiteApi(self._policy_store, self.store, self.runner)
+        self.api = SiteRestApi(self._policy_store, self.store, self.runner)
         self.server = SiteServer(self.api)
 
         # Client side

--- a/proof_of_concept/ddm_site.py
+++ b/proof_of_concept/ddm_site.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__file__)
 
 
 class Site:
-    """Represents a single DDM peer installation."""
+    """Represents a single DDM installation."""
     def __init__(
             self, name: str, owner: str,
             namespace: str, stored_data: List[Asset],
@@ -88,7 +88,7 @@ class Site:
         self.store = AssetStore(self._policy_evaluator)
 
         self.runner = StepRunner(
-                name, self._registry_client, self._peer_client,
+                name, self._registry_client, self._site_rest_client,
                 self._policy_evaluator, self.store)
 
         # REST server
@@ -98,7 +98,7 @@ class Site:
         # Client side
         self._workflow_engine = WorkflowOrchestrator(
                 self._policy_evaluator, self._registry_client,
-                self._peer_client)
+                self._site_rest_client)
 
         # Register site with DDM
         self._registry_client.register_site(

--- a/proof_of_concept/ddm_site.py
+++ b/proof_of_concept/ddm_site.py
@@ -9,7 +9,7 @@ import ruamel.yaml as yaml
 
 from proof_of_concept.asset import Asset
 from proof_of_concept.asset_store import AssetStore
-from proof_of_concept.ddm_client import PeerClient, RegistryClient
+from proof_of_concept.ddm_client import SiteRestClient, RegistryClient
 from proof_of_concept.ddm_site_api import SiteRestApi, SiteServer
 from proof_of_concept.definitions import PartyDescription, SiteDescription
 from proof_of_concept.step_runner import StepRunner
@@ -60,7 +60,7 @@ class Site:
 
         # Create clients for talking to the DDM
         self._registry_client = RegistryClient()
-        self._peer_client = PeerClient(
+        self._peer_client = SiteRestClient(
                 self.name, self._site_validator, self._registry_client)
 
         # Register party with DDM

--- a/proof_of_concept/ddm_site.py
+++ b/proof_of_concept/ddm_site.py
@@ -14,7 +14,7 @@ from proof_of_concept.ddm_site_api import SiteRestApi, SiteServer
 from proof_of_concept.definitions import PartyDescription, SiteDescription
 from proof_of_concept.step_runner import StepRunner
 from proof_of_concept.policy import PolicyEvaluator, Rule
-from proof_of_concept.policy_replication import PolicyStore, PolicySource
+from proof_of_concept.policy_replication import PolicyStore, PolicyClient
 from proof_of_concept.replication import CanonicalStore, ReplicableArchive
 from proof_of_concept.validation import Validator
 from proof_of_concept.workflow import Job
@@ -80,9 +80,9 @@ class Site:
             rule.sign(self._private_key)
             self._policy_store.insert(rule)
 
-        self._policy_source = PolicySource(
+        self._policy_client = PolicyClient(
                 self._registry_client, self._site_validator)
-        self._policy_evaluator = PolicyEvaluator(self._policy_source)
+        self._policy_evaluator = PolicyEvaluator(self._policy_client)
 
         # Server side
         self.store = AssetStore(self._policy_evaluator)

--- a/proof_of_concept/ddm_site_api.py
+++ b/proof_of_concept/ddm_site_api.py
@@ -21,10 +21,10 @@ from proof_of_concept.validation import Validator, ValidationError
 logger = logging.getLogger(__name__)
 
 
-class AssetAccess:
+class AssetAccessHandler:
     """A handler for the /assets endpoint."""
     def __init__(self, store: IAssetStore) -> None:
-        """Create an AssetAccess handler.
+        """Create an AssetAccessHandler handler.
 
         Args:
             store: The asset store to send requests to.
@@ -71,12 +71,12 @@ class AssetAccess:
                 response.body = 'Asset not found'
 
 
-class WorkflowExecution:
+class WorkflowExecutionHandler:
     """A handler for the /jobs endpoint."""
     def __init__(
             self, runner: IStepRunner, validator: Validator
             ) -> None:
-        """Create a WorkflowExecution handler.
+        """Create a WorkflowExecutionHandler handler.
 
         Args:
             runner: The runner to send requests to.
@@ -135,10 +135,10 @@ class SiteApi:
         rule_replication = ReplicationHandler[Rule](policy_store)
         self.app.add_route('/rules/updates', rule_replication)
 
-        asset_access = AssetAccess(asset_store)
+        asset_access = AssetAccessHandler(asset_store)
         self.app.add_route('/assets/{asset_id}', asset_access)
 
-        workflow_execution = WorkflowExecution(runner, validator)
+        workflow_execution = WorkflowExecutionHandler(runner, validator)
         self.app.add_route('/jobs', workflow_execution)
 
 

--- a/proof_of_concept/ddm_site_api.py
+++ b/proof_of_concept/ddm_site_api.py
@@ -104,7 +104,7 @@ class WorkflowExecutionHandler:
             response.body = 'Invalid request'
 
 
-class SiteApi:
+class SiteRestApi:
     """The complete Site REST API.
 
     Attributes:
@@ -116,7 +116,7 @@ class SiteApi:
             policy_store: PolicyStore,
             asset_store: IAssetStore,
             runner: IStepRunner) -> None:
-        """Create a RegistryApi instance.
+        """Create a SiteRestApi instance.
 
         Args:
             policy_store: The store to offer policy updates from.
@@ -148,7 +148,7 @@ class ThreadingWSGIServer (ThreadingMixIn, WSGIServer):
 
 
 class SiteServer:
-    """An HTTP server serving a SiteApi.
+    """An HTTP server serving a SiteRestApi.
 
     Make sure to call `close()` when you're done, or the program will
     not shut down because the background thread will still be running.
@@ -157,7 +157,7 @@ class SiteServer:
         endpoint: The HTTP endpoint at which the server can be reached.
 
     """
-    def __init__(self, api: SiteApi) -> None:
+    def __init__(self, api: SiteRestApi) -> None:
         """Create a SiteServer serving an API.
 
         This starts a background thread with an HTTP server.

--- a/proof_of_concept/definitions.py
+++ b/proof_of_concept/definitions.py
@@ -162,7 +162,7 @@ class ReplicaUpdate(Generic[T]):
             f' {self.valid_until}, +{self.created}, -{self.deleted})')
 
 
-class IReplicationSource(Generic[T]):
+class IReplicationService(Generic[T]):
     """Generic interface for replication sources."""
     def get_updates_since(self, from_version: int) -> ReplicaUpdate[T]:
         """Return a set of objects modified since the given version.
@@ -178,7 +178,7 @@ class IReplicationSource(Generic[T]):
         raise NotImplementedError()
 
 
-IPolicyServer = IReplicationSource[Rule]
+IPolicyServer = IReplicationService[Rule]
 
 
 class RegisteredObject:

--- a/proof_of_concept/definitions.py
+++ b/proof_of_concept/definitions.py
@@ -178,9 +178,6 @@ class IReplicationService(Generic[T]):
         raise NotImplementedError()
 
 
-IPolicyServer = IReplicationService[Rule]
-
-
 class RegisteredObject:
     """Base class for objects in the registry."""
     pass

--- a/proof_of_concept/policy.py
+++ b/proof_of_concept/policy.py
@@ -146,7 +146,7 @@ class Permissions:
         return 'Permissions({})'.format(repr(self._sets))
 
 
-class IPolicySource:
+class IPolicyCollection:
     """Provides policies to a PolicyEvaluator."""
     def policies(self) -> Iterable[Rule]:
         """Returns an iterable collection of rules."""
@@ -155,13 +155,13 @@ class IPolicySource:
 
 class PolicyEvaluator:
     """Interprets policies to support planning and execution."""
-    def __init__(self, policy_source: IPolicySource) -> None:
+    def __init__(self, policy_collection: IPolicyCollection) -> None:
         """Create a PolicyEvaluator.
 
         Args:
-            policy_source: A source of policies to evaluate.
+            policy_collection: A collections of policies to evaluate.
         """
-        self._policy_source = policy_source
+        self._policy_collection = policy_collection
 
     def permissions_for_asset(self, asset: str) -> Permissions:
         """Returns permissions for the given asset.
@@ -226,7 +226,7 @@ class PolicyEvaluator:
         """
         def matches_one(asset_set: Set[str], site: str) -> bool:
             for asset in asset_set:
-                for rule in self._policy_source.policies():
+                for rule in self._policy_collection.policies():
                     if isinstance(rule, MayAccess):
                         if rule.asset == asset and rule.site == site:
                             return True
@@ -252,7 +252,7 @@ class PolicyEvaluator:
             cur_parties.extend(new_parties)
             new_parties = list()
             for party in cur_parties:
-                for rule in self._policy_source.policies():
+                for rule in self._policy_collection.policies():
                     if isinstance(rule, InPartyCollection):
                         if rule.party == party:
                             new_parties.append(rule.collection)
@@ -273,7 +273,7 @@ class PolicyEvaluator:
             cur_assets |= new_assets
             new_assets = set()
             for asset in cur_assets:
-                for rule in self._policy_source.policies():
+                for rule in self._policy_collection.policies():
                     if isinstance(rule, InAssetCollection):
                         if rule.asset == asset:
                             if rule.collection not in cur_assets:
@@ -301,7 +301,7 @@ class PolicyEvaluator:
             """Gets all matching rules for the given single asset."""
             result = list()     # type: List[ResultOfIn]
             assets = self._equivalent_assets(asset)
-            for rule in self._policy_source.policies():
+            for rule in self._policy_collection.policies():
                 if isinstance(rule, typ):
                     for asset in assets:
                         if rule.data_asset == asset:

--- a/proof_of_concept/policy_replication.py
+++ b/proof_of_concept/policy_replication.py
@@ -9,13 +9,13 @@ from proof_of_concept.policy import (
         ResultOfDataIn, ResultOfComputeIn, Rule)
 from proof_of_concept.replication import (
         CanonicalStore, ObjectValidator, Replica)
-from proof_of_concept.replication_rest import ReplicationClient
+from proof_of_concept.replication_rest import ReplicationRestClient
 from proof_of_concept.validation import Validator
 
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 
-class PolicyClient(ReplicationClient[Rule]):
+class PolicyClient(ReplicationRestClient[Rule]):
     """A client for policy servers."""
     UpdateType = PolicyUpdate
 

--- a/proof_of_concept/policy_replication.py
+++ b/proof_of_concept/policy_replication.py
@@ -15,7 +15,7 @@ from proof_of_concept.validation import Validator
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 
-class PolicyClient(ReplicationRestClient[Rule]):
+class PolicyRestClient(ReplicationRestClient[Rule]):
     """A client for policy servers."""
     UpdateType = PolicyUpdate
 
@@ -97,7 +97,7 @@ class PolicySource(IPolicyCollection):
         """
         for o in created:
             if isinstance(o, SiteDescription) and o.namespace:
-                client = PolicyClient(
+                client = PolicyRestClient(
                         o.endpoint + '/rules/updates', self._site_validator)
 
                 key = self._registry_client.get_public_key_for_ns(o.namespace)

--- a/proof_of_concept/policy_replication.py
+++ b/proof_of_concept/policy_replication.py
@@ -5,7 +5,7 @@ from proof_of_concept.ddm_client import RegistryClient
 from proof_of_concept.definitions import (
         PolicyUpdate, RegisteredObject, SiteDescription)
 from proof_of_concept.policy import (
-        IPolicySource, InPartyCollection, InAssetCollection, MayAccess,
+        IPolicyCollection, InPartyCollection, InAssetCollection, MayAccess,
         ResultOfDataIn, ResultOfComputeIn, Rule)
 from proof_of_concept.replication import (
         CanonicalStore, ObjectValidator, Replica)
@@ -53,7 +53,7 @@ class RuleValidator(ObjectValidator[Rule]):
         return rule.has_valid_signature(self._key)
 
 
-class PolicySource(IPolicySource):
+class PolicySource(IPolicyCollection):
     """Ties together various sources of policies."""
     def __init__(
             self, registry_client: RegistryClient, site_validator: Validator

--- a/proof_of_concept/policy_replication.py
+++ b/proof_of_concept/policy_replication.py
@@ -53,12 +53,12 @@ class RuleValidator(ObjectValidator[Rule]):
         return rule.has_valid_signature(self._key)
 
 
-class PolicySource(IPolicyCollection):
+class PolicyClient(IPolicyCollection):
     """Ties together various sources of policies."""
     def __init__(
             self, registry_client: RegistryClient, site_validator: Validator
             ) -> None:
-        """Create a PolicySource.
+        """Create a PolicyClient.
 
         This will automatically keep the replicas up-to-date as needed.
 

--- a/proof_of_concept/registry.py
+++ b/proof_of_concept/registry.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from proof_of_concept.definitions import (
-        IAssetStore, IPolicyServer, PartyDescription,
+        IAssetStore, PartyDescription,
         RegisteredObject, RegistryUpdate, SiteDescription)
 from proof_of_concept.replication import CanonicalStore, ReplicableArchive
 

--- a/proof_of_concept/registry_api.py
+++ b/proof_of_concept/registry_api.py
@@ -132,7 +132,7 @@ class SiteRegistrationHandler:
             response.body = 'Not found'
 
 
-class RegistryApi:
+class RegistryRestApi:
     """The complete Registry REST API.
 
     Attributes:
@@ -140,7 +140,7 @@ class RegistryApi:
 
     """
     def __init__(self, registry: Registry) -> None:
-        """Create a RegistryApi instance.
+        """Create a RegistryRestApi instance.
 
         Args:
             registry: The registry to serve for.

--- a/proof_of_concept/registry_api.py
+++ b/proof_of_concept/registry_api.py
@@ -19,13 +19,13 @@ from proof_of_concept.validation import Validator, ValidationError
 logger = logging.getLogger(__name__)
 
 
-class PartyRegistration:
+class PartyRegistrationHandler:
     """A handler for the /parties endpoint."""
     def __init__(
             self,
             registry: Registry,
             validator: Validator) -> None:
-        """Create a PartyRegistration handler.
+        """Create a PartyRegistrationHandler handler.
 
         Args:
             registry: The registry to send requests to.
@@ -77,10 +77,10 @@ class PartyRegistration:
             response.body = 'Not found'
 
 
-class SiteRegistration:
+class SiteRegistrationHandler:
     """A handler for the /sites endpoint."""
     def __init__(self, registry: Registry, validator: Validator) -> None:
-        """Create a SiteRegistration handler.
+        """Create a SiteRegistrationHandler handler.
 
         Args:
             registry: The registry to send requests to.
@@ -154,11 +154,11 @@ class RegistryApi:
 
         validator = Validator(registry_api_def)
 
-        party_registration = PartyRegistration(registry, validator)
+        party_registration = PartyRegistrationHandler(registry, validator)
         self.app.add_route('/parties', party_registration)
         self.app.add_route('/parties/{name}', party_registration)
 
-        site_registration = SiteRegistration(registry, validator)
+        site_registration = SiteRegistrationHandler(registry, validator)
         self.app.add_route('/sites', site_registration)
         self.app.add_route('/sites/{name}', site_registration)
 

--- a/proof_of_concept/replication.py
+++ b/proof_of_concept/replication.py
@@ -19,7 +19,7 @@ from typing import (
         Any, Callable, Dict, Generic, Iterable, Optional, Set, Tuple, Type,
         TypeVar)
 
-from proof_of_concept.definitions import IReplicationSource, ReplicaUpdate
+from proof_of_concept.definitions import IReplicationService, ReplicaUpdate
 
 
 logger = logging.getLogger(__name__)
@@ -71,7 +71,7 @@ class ReplicableArchive(Generic[T]):
         self.version = 0            # type: int
 
 
-class CanonicalStore(IReplicationSource[T]):
+class CanonicalStore(IReplicationService[T]):
     """Stores Replicables and can be replicated."""
     UpdateType = ReplicaUpdate[T]   # type: Type[ReplicaUpdate[T]]
 
@@ -171,7 +171,7 @@ class ObjectValidator(Generic[T]):
 class Replica(Generic[T]):
     """Stores a replica of a CanonicalStore."""
     def __init__(
-            self, source: IReplicationSource[T],
+            self, source: IReplicationService[T],
             validator: Optional[ObjectValidator[T]] = None,
             on_update: Optional[Callable[[Set[T], Set[T]], None]] = None
             ) -> None:

--- a/proof_of_concept/replication_rest.py
+++ b/proof_of_concept/replication_rest.py
@@ -42,16 +42,17 @@ class ReplicationHandler(Generic[T]):
         response.media = serialize(updates)
 
 
-class ReplicationClient(IReplicationService[T]):
+class ReplicationRestClient(IReplicationService[T]):
     """Client for a ReplicationHandler REST endpoint."""
     UpdateType = ReplicaUpdate[T]   # type: Type[ReplicaUpdate[T]]
 
     def __init__(self, endpoint: str, validator: Validator) -> None:
-        """Create a ReplicationClient.
+        """Create a ReplicationRestClient.
 
-        Note that replicated_type must match T, one is used by the
-        type checker, the other is available at runtime to help us
-        deserialize the correct type.
+        Note that UpdateType must be set to ReplicaUpdate[T] with the
+        actual T when using this, one is used by the type checker, the
+        other is available at runtime to help us deserialize the
+        correct type.
 
         Args:
             endpoint: URL of the endpoint to connect to.

--- a/proof_of_concept/replication_rest.py
+++ b/proof_of_concept/replication_rest.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Generic, Optional, Type, TypeVar
 from falcon import Request, Response
 
 from proof_of_concept.definitions import (
-        IReplicationSource, ReplicaUpdate)
+        IReplicationService, ReplicaUpdate)
 from proof_of_concept.replication import ReplicableArchive
 from proof_of_concept.serialization import serialize, deserialize
 from proof_of_concept.validation import Validator
@@ -20,13 +20,13 @@ T = TypeVar('T')
 
 class ReplicationHandler(Generic[T]):
     """A handler for a /updates REST API endpoint."""
-    def __init__(self, source: IReplicationSource[T]) -> None:
+    def __init__(self, service: IReplicationService[T]) -> None:
         """Create a Replication handler.
 
         Args:
-            source: The source to get updates from.
+            service: The service to get updates from.
         """
-        self._source = source
+        self._service = service
 
     def on_get(self, request: Request, response: Response) -> None:
         """Handle a registry update request.
@@ -38,11 +38,11 @@ class ReplicationHandler(Generic[T]):
         from_version = request.get_param_as_int(
                 'from_version', required=True)
 
-        updates = self._source.get_updates_since(from_version)
+        updates = self._service.get_updates_since(from_version)
         response.media = serialize(updates)
 
 
-class ReplicationClient(IReplicationSource[T]):
+class ReplicationClient(IReplicationService[T]):
     """Client for a ReplicationHandler REST endpoint."""
     UpdateType = ReplicaUpdate[T]   # type: Type[ReplicaUpdate[T]]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ import pytest
 # then we'll have an object inside the fixture
 from proof_of_concept.ddm_client import global_registry
 from proof_of_concept.registry import Registry
-from proof_of_concept.registry_api import RegistryApi
+from proof_of_concept.registry_api import RegistryRestApi
 
 log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 logging.basicConfig(level=logging.INFO, format=log_format)
@@ -47,7 +47,7 @@ def registry_server():
     # Need to reimport, because we changed it in the fixture above
     # Will disappear, see above
     from proof_of_concept.ddm_client import global_registry
-    api = RegistryApi(global_registry)
+    api = RegistryRestApi(global_registry)
     server = ReusingWSGIServer(('0.0.0.0', 4413), WSGIRequestHandler)
     server.set_app(api.app)
     thread = Thread(


### PR DESCRIPTION
This addresses #25 and #33. I've also added some documentation describing the naming system now in use.