### PR TITLE
Task 1244: Rule.signing_namespace()

### DIFF
--- a/proof_of_concept/definitions/policy.py
+++ b/proof_of_concept/definitions/policy.py
@@ -4,4 +4,6 @@ from proof_of_concept.definitions.signable import Signable
 
 class Rule(Signable):
     """Abstract base class for policy rules."""
-    pass
+    def signing_namespace(self) -> str:
+        """Return the namespace whose owner must sign this rule."""
+        raise NotImplemented

--- a/proof_of_concept/policy/replication.py
+++ b/proof_of_concept/policy/replication.py
@@ -31,19 +31,7 @@ class RuleValidator(ObjectValidator[Rule]):
 
     def is_valid(self, rule: Rule) -> bool:
         """Return True iff the rule is properly signed."""
-        if isinstance(rule, ResultOfDataIn):
-            namespace = rule.data_asset.split(':')[1]
-        elif isinstance(rule, ResultOfComputeIn):
-            namespace = rule.compute_asset.split(':')[1]
-        elif isinstance(rule, MayAccess):
-            namespace = rule.asset.split(':')[1]
-        elif isinstance(rule, InAssetCollection):
-            namespace = rule.asset.split(':')[1]
-        elif isinstance(rule, InPartyCollection):
-            namespace = rule.collection.split(':')[1]
-
-        logger.info(f'Rule namespace {namespace}, should be {self._namespace}')
-        if namespace != self._namespace:
+        if rule.signing_namespace() != self._namespace:
             return False
         return rule.has_valid_signature(self._key)
 

--- a/proof_of_concept/policy/rules.py
+++ b/proof_of_concept/policy/rules.py
@@ -36,10 +36,14 @@ class InAssetCollection(Rule):
         """
         return '{}|{}'.format(self.asset, self.collection).encode('utf-8')
 
+    def signing_namespace(self) -> str:
+        """Return the namespace whose owner must sign this rule."""
+        return self.asset.namespace()
+
 
 class InPartyCollection(Rule):
     """Says that Party party is in PartyCollection collection."""
-    def __init__(self, party: str, collection: str) -> None:
+    def __init__(self, party: str, collection: Union[str, AssetId]) -> None:
         """Create an InPartyCollection rule.
 
         Args:
@@ -47,6 +51,8 @@ class InPartyCollection(Rule):
             collection: The collection it is in.
         """
         self.party = party
+        if not isinstance(collection, AssetId):
+            collection = AssetId(collection)
         self.collection = collection
 
     def __repr__(self) -> str:
@@ -59,6 +65,10 @@ class InPartyCollection(Rule):
         This adapts the Signable base class to this class.
         """
         return '{}|{}'.format(self.party, self.collection).encode('utf-8')
+
+    def signing_namespace(self) -> str:
+        """Return the namespace whose owner must sign this rule."""
+        return self.collection.namespace()
 
 
 class MayAccess(Rule):
@@ -83,6 +93,10 @@ class MayAccess(Rule):
         This adapts the Signable base class to this class.
         """
         return f'{self.site}|{self.asset}'.encode('utf-8')
+
+    def signing_namespace(self) -> str:
+        """Return the namespace whose owner must sign this rule."""
+        return self.asset.namespace()
 
 
 class ResultOfIn(Rule):
@@ -132,9 +146,13 @@ class ResultOfIn(Rule):
 
 class ResultOfDataIn(ResultOfIn):
     """ResultOfIn rule on behalf of the data asset owner."""
-    pass
+    def signing_namespace(self) -> str:
+        """Return the namespace whose owner must sign this rule."""
+        return self.data_asset.namespace()
 
 
 class ResultOfComputeIn(ResultOfIn):
     """ResultOfIn rule on behalf of the compute asset owner."""
-    pass
+    def signing_namespace(self) -> str:
+        """Return the namespace whose owner must sign this rule."""
+        return self.compute_asset.namespace()


### PR DESCRIPTION
This adds a `signing_namespace()` method to the Rule ABC, and implements it for the various rules. That simplifies the implementation of `RuleValidator`.

Also, we're now using an `AssetId` to identify a party collection, which sounds a bit odd. Maybe we should rename `AssetId` to `Identifier` and use it for parties and party collections as well; I've made a new PBI 1254 for this.

This applies on top of #47, so that should be merged first.