### PR TITLE
Use __name__ to name loggers, not __file__

### DIFF
--- a/proof_of_concept/components/asset_store.py
+++ b/proof_of_concept/components/asset_store.py
@@ -8,7 +8,7 @@ from proof_of_concept.policy.evaluation import (
         PermissionCalculator, PolicyEvaluator)
 
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class AssetStore(IAssetStore):

--- a/proof_of_concept/components/ddm_site.py
+++ b/proof_of_concept/components/ddm_site.py
@@ -25,7 +25,7 @@ from proof_of_concept.components.orchestration import WorkflowOrchestrator
 from proof_of_concept.components.policy_client import PolicyClient
 
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class Site:

--- a/proof_of_concept/components/orchestration.py
+++ b/proof_of_concept/components/orchestration.py
@@ -13,7 +13,7 @@ from proof_of_concept.policy.evaluation import (
 from proof_of_concept.rest.client import SiteRestClient
 
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class WorkflowPlanner:

--- a/proof_of_concept/components/step_runner.py
+++ b/proof_of_concept/components/step_runner.py
@@ -16,7 +16,7 @@ from proof_of_concept.components.asset_store import AssetStore
 from proof_of_concept.components.registry_client import RegistryClient
 
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class JobRun(Thread):


### PR DESCRIPTION
Not sure how we missed this, but some of the loggers are named using `__file__`, while the Python convention is to use `__name__` so you can control log output per module. This PR fixes that.

This goes on top of #48; ignore all but the top commit.