### PR TITLE
Clean up id/name/key/item terminology

### DIFF
--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -2,6 +2,102 @@
 Terminology
 ===========
 
+Naming objects in and around the DDM
+====================================
+
+There are different kinds of objects in the DDM which need to be distinguished
+from other objects of the same kind. So they need some kind of unique
+identifier.
+
+Identifiers in the DDM are strings consisting of colon-separated components. The
+first component is a fixed string designating the type of object being
+identified. One or more components follow depending on the type (see below).
+Components may contain lower- and uppercase letters, digits, underscores,
+dashes, and periods.
+
+Here are some of those kinds of objects and how they are identified.
+
+Party
+  A party is a real-world entity which takes part in the DDM, usually an
+  organization. Parties may own or administer sites. Parties are uniquely
+  identified using an identifier of the form::
+
+    party:<namespace>:<name>
+
+  The ``<namespace>`` component is expected to be a DNS (sub-)domain, while
+  ``<name>`` can be any valid component.
+
+Party Collection
+  A party collection is a group of parties. It is used to organize parties and
+  make it easier to define rules that apply to multiple parties. Party
+  collections are identified using an identifier of the form::
+
+    party_collection:<namespace>:<name>
+
+  The ``<namespace>`` component is expected to be a DNS (sub-)domain, while
+  ``<name>`` can be any valid component.
+
+Site
+  A site is a running software installation which takes part in the DDM. Sites
+  have an owner (a Party) and an administrator (also a Party). Sites are
+  uniquely identified using an identifier of the form::
+
+    site:<namespace>:<name>
+
+  The ``<namespace>`` component is expected to be a DNS (sub-)domain, while
+  ``<name>`` can be any valid component.
+
+Asset
+  An asset is either a data set or a software component. Assets are identified
+  using an Identifier of the form::
+
+    asset:<namespace>:<name>:<site_namespace>:<site_name>
+
+  The ``<namespace>`` and ``<name>`` components are as above.
+  ``<site_namespace>`` and ``<site_name>`` refer to the site from which the
+  asset is available, ``site:<site_namespace>:<site_name>``.
+
+AssetCollection
+  An asset collection is a group of assets. It is used to organize assets and
+  make it easier to define rules that apply to multiple assets. Asset
+  collections are identified using an identifier of the form::
+
+    asset_collection:<namespace>:<name>
+
+  The ``<namespace>`` component is expected to be a DNS (sub-)domain, while
+  ``<name>`` can be any valid component.
+
+Result
+  A result is a data set that is an intermediate or final result of processing
+  data using a workflow. Results are identified by an identifier of the form::
+
+    result:<id_hash>
+
+  The ``<id_hash>`` is a string of letters and digits calculated from (the part
+  of) the workflow that was used to produce the result.
+
+Workflow item
+  A workflow item is a workflow input, workflow output, workflow step, workflow
+  step input, or workflow step output. In the context of dealing with
+  permissions for and execution of workflows, it's needed to refer to these.
+  This is done using a string that is not an identifier as described above, but
+  a simple string of one of the forms::
+
+    <workflow_input_name>
+    <workflow_output_name>
+    <step_name>
+    <step_name>.<input_name>
+    <step_name>.<output_name>
+
+  Steps, inputs and outputs are identified by their name, which is a simple
+  string consisting of lower- and uppercase letters, digits, and underscores.
+  Note that the Workflow class forbids duplicate names among workflow inputs,
+  workflow outputs, and steps, so that these are unique within the context of a
+  specific workflow.
+
+Class names
+===========
+
 This proof-of-concept contains quite a few classes which play different roles in
 the system. They're named systematically, so that we have some hope of being
 able to see what is what. Here's a key to class names:

--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -9,10 +9,10 @@ There are different kinds of objects in the DDM which need to be distinguished
 from other objects of the same kind. So they need some kind of unique
 identifier.
 
-Identifiers in the DDM are strings consisting of colon-separated components. The
-first component is a fixed string designating the type of object being
-identified. One or more components follow depending on the type (see below).
-Components may contain lower- and uppercase letters, digits, underscores,
+Identifiers in the DDM are strings consisting of colon-separated segments. The
+first segment is a fixed string designating the type of object being
+identified. One or more segments follow depending on the type (see below).
+Segments may contain lower- and uppercase letters, digits, underscores,
 dashes, and periods.
 
 Here are some of those kinds of objects and how they are identified.
@@ -24,8 +24,8 @@ Party
 
     party:<namespace>:<name>
 
-  The ``<namespace>`` component is expected to be a DNS (sub-)domain, while
-  ``<name>`` can be any valid component.
+  The ``<namespace>`` segment is expected to be a DNS (sub-)domain, while
+  ``<name>`` can be any valid segment.
 
 Party Collection
   A party collection is a group of parties. It is used to organize parties and
@@ -34,8 +34,8 @@ Party Collection
 
     party_collection:<namespace>:<name>
 
-  The ``<namespace>`` component is expected to be a DNS (sub-)domain, while
-  ``<name>`` can be any valid component.
+  The ``<namespace>`` segment is expected to be a DNS (sub-)domain, while
+  ``<name>`` can be any valid segment.
 
 Site
   A site is a running software installation which takes part in the DDM. Sites
@@ -44,16 +44,16 @@ Site
 
     site:<namespace>:<name>
 
-  The ``<namespace>`` component is expected to be a DNS (sub-)domain, while
-  ``<name>`` can be any valid component.
+  The ``<namespace>`` segment is expected to be a DNS (sub-)domain, while
+  ``<name>`` can be any valid segment.
 
 Asset
-  An asset is either a data set or a software component. Assets are identified
+  An asset is either a data set or a software segment. Assets are identified
   using an Identifier of the form::
 
     asset:<namespace>:<name>:<site_namespace>:<site_name>
 
-  The ``<namespace>`` and ``<name>`` components are as above.
+  The ``<namespace>`` and ``<name>`` segments are as above.
   ``<site_namespace>`` and ``<site_name>`` refer to the site from which the
   asset is available, ``site:<site_namespace>:<site_name>``.
 
@@ -64,8 +64,8 @@ AssetCollection
 
     asset_collection:<namespace>:<name>
 
-  The ``<namespace>`` component is expected to be a DNS (sub-)domain, while
-  ``<name>`` can be any valid component.
+  The ``<namespace>`` segment is expected to be a DNS (sub-)domain, while
+  ``<name>`` can be any valid segment.
 
 Result
   A result is a data set that is an intermediate or final result of processing

--- a/proof_of_concept/components/asset_store.py
+++ b/proof_of_concept/components/asset_store.py
@@ -2,7 +2,8 @@
 import logging
 from typing import Dict
 
-from proof_of_concept.definitions.assets import Asset, AssetId
+from proof_of_concept.definitions.assets import Asset
+from proof_of_concept.definitions.identifier import Identifier
 from proof_of_concept.definitions.interfaces import IAssetStore
 from proof_of_concept.policy.evaluation import (
         PermissionCalculator, PolicyEvaluator)
@@ -17,7 +18,7 @@ class AssetStore(IAssetStore):
         """Create a new empty AssetStore."""
         self._policy_evaluator = policy_evaluator
         self._permission_calculator = PermissionCalculator(policy_evaluator)
-        self._assets = dict()  # type: Dict[AssetId, Asset]
+        self._assets = dict()  # type: Dict[Identifier, Asset]
 
     def store(self, asset: Asset) -> None:
         """Stores an asset.
@@ -34,7 +35,7 @@ class AssetStore(IAssetStore):
 
         self._assets[asset.id] = asset
 
-    def retrieve(self, asset_id: AssetId, requester: str
+    def retrieve(self, asset_id: Identifier, requester: str
                  ) -> Asset:
         """Retrieves an asset.
 

--- a/proof_of_concept/components/orchestration.py
+++ b/proof_of_concept/components/orchestration.py
@@ -54,8 +54,8 @@ class WorkflowPlanner:
             """Check whether the given site may run the given step."""
             # check each input
             for inp_name in step.inputs:
-                inp_key = '{}.{}'.format(step.name, inp_name)
-                inp_perms = permissions[inp_key]
+                inp_item = '{}.{}'.format(step.name, inp_name)
+                inp_perms = permissions[inp_item]
                 if not self._policy_evaluator.may_access(inp_perms, site):
                     return False
 
@@ -66,8 +66,8 @@ class WorkflowPlanner:
 
             # check each output
             for outp_name in step.outputs:
-                outp_key = '{}.{}'.format(step.name, outp_name)
-                outp_perms = permissions[outp_key]
+                outp_item = '{}.{}'.format(step.name, outp_name)
+                outp_perms = permissions[outp_item]
                 if not self._policy_evaluator.may_access(outp_perms, site):
                     return False
 

--- a/proof_of_concept/components/orchestration.py
+++ b/proof_of_concept/components/orchestration.py
@@ -5,7 +5,7 @@ from time import sleep
 from typing import Any, Dict, Generator, List
 
 from proof_of_concept.components.registry_client import RegistryClient
-from proof_of_concept.definitions.asset_id import AssetId
+from proof_of_concept.definitions.identifier import Identifier
 from proof_of_concept.definitions.workflows import (
         Job, JobSubmission, Plan, Workflow, WorkflowStep)
 from proof_of_concept.policy.evaluation import (
@@ -166,7 +166,7 @@ class WorkflowExecutor:
                     src_site = submission.plan.step_sites[src_step_name]
                     outp_id_hash = id_hashes[wf_outp_name]
                     try:
-                        asset_id = AssetId.from_id_hash(outp_id_hash)
+                        asset_id = Identifier.from_id_hash(outp_id_hash)
                         asset = self._site_rest_client.retrieve_asset(
                                 src_site, asset_id)
                         results[wf_outp_name] = asset.data

--- a/proof_of_concept/components/orchestration.py
+++ b/proof_of_concept/components/orchestration.py
@@ -157,16 +157,16 @@ class WorkflowExecutor:
 
         # get workflow outputs whenever they're available
         wf = submission.job.workflow
-        keys = submission.job.keys()
+        id_hashes = submission.job.id_hashes()
         results = dict()    # type: Dict[str, Any]
         while len(results) < len(wf.outputs):
             for wf_outp_name, wf_outp_source in wf.outputs.items():
                 if wf_outp_name not in results:
                     src_step_name, src_step_output = wf_outp_source.split('.')
                     src_site = submission.plan.step_sites[src_step_name]
-                    outp_key = keys[wf_outp_name]
+                    outp_id_hash = id_hashes[wf_outp_name]
                     try:
-                        asset_id = AssetId.from_key(outp_key)
+                        asset_id = AssetId.from_id_hash(outp_id_hash)
                         asset = self._site_rest_client.retrieve_asset(
                                 src_site, asset_id)
                         results[wf_outp_name] = asset.data

--- a/proof_of_concept/components/registry_client.py
+++ b/proof_of_concept/components/registry_client.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, List, Optional, Set
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 import ruamel.yaml as yaml
 
-from proof_of_concept.definitions.assets import AssetId
 from proof_of_concept.definitions.registry import (
         PartyDescription, RegisteredObject, SiteDescription)
 from proof_of_concept.rest.serialization import serialize

--- a/proof_of_concept/components/registry_client.py
+++ b/proof_of_concept/components/registry_client.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, List, Optional, Set
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 import ruamel.yaml as yaml
 
+from proof_of_concept.definitions.identifier import Identifier
 from proof_of_concept.definitions.registry import (
         PartyDescription, RegisteredObject, SiteDescription)
 from proof_of_concept.rest.serialization import serialize
@@ -85,14 +86,14 @@ class RegistryClient:
                 self._registry_endpoint + '/parties',
                 json=serialize(description))
 
-    def deregister_party(self, name: str) -> None:
+    def deregister_party(self, party: Identifier) -> None:
         """Deregister a party with the Registry.
 
         Args:
-            name: Name of the party to deregister.
+            party: The party to deregister.
 
         """
-        r = requests.delete(f'{self._registry_endpoint}/parties/{name}')
+        r = requests.delete(f'{self._registry_endpoint}/parties/{party}')
         if r.status_code == 404:
             raise KeyError('Party not found')
 
@@ -107,14 +108,14 @@ class RegistryClient:
                 self._registry_endpoint + '/sites',
                 json=serialize(description))
 
-    def deregister_site(self, name: str) -> None:
+    def deregister_site(self, site: Identifier) -> None:
         """Deregister a site with the Registry.
 
         Args:
-            name: Name of the site to deregister.
+            site: The site to deregister.
 
         """
-        r = requests.delete(f'{self._registry_endpoint}/sites/{name}')
+        r = requests.delete(f'{self._registry_endpoint}/sites/{site}')
         if r.status_code == 404:
             raise KeyError('Site not found')
 
@@ -124,7 +125,7 @@ class RegistryClient:
         # already.
         site = self._get_site('namespace', namespace)
         if site is not None:
-            owner = self._get_party(site.owner_name)
+            owner = self._get_party(site.owner_id)
             if owner is None:
                 raise RuntimeError(f'Registry replica is broken')
             return owner.public_key
@@ -137,32 +138,32 @@ class RegistryClient:
         for o in self._registry_replica.objects:
             if isinstance(o, SiteDescription):
                 if o.runner:
-                    sites.append(o.name)
+                    sites.append(o.id)
         return sites
 
-    def get_site_by_name(self, site_name: str) -> SiteDescription:
-        """Gets a site's description by name.
+    def get_site_by_id(self, site_id: Identifier) -> SiteDescription:
+        """Gets a site's description by id.
 
         Args:
-            site_name: Name of the site to look up.
+            site_id: Identifier of the site to look up.
 
         Returns:
             The description of the corresponding site.
 
         Raises:
-            KeyError: If no site with that name exists.
+            KeyError: If no site with that id exists.
 
         """
-        site = self._get_site('name', site_name)
+        site = self._get_site('id', site_id)
         if not site:
-            raise KeyError(f'Site named {site_name} not found')
+            raise KeyError(f'Site with id {site_id} not found')
         return site
 
-    def _get_party(self, name: str) -> Optional[PartyDescription]:
-        """Returns the party with the given name."""
+    def _get_party(self, party_id: Identifier) -> Optional[PartyDescription]:
+        """Returns the party with the given id."""
         for o in self._registry_replica.objects:
             if isinstance(o, PartyDescription):
-                if o.name == name:
+                if o.id == party_id:
                     return o
         return None
 

--- a/proof_of_concept/components/step_runner.py
+++ b/proof_of_concept/components/step_runner.py
@@ -4,7 +4,7 @@ from threading import Thread
 from time import sleep
 from typing import Any, Dict, Optional, Tuple
 
-from proof_of_concept.definitions.asset_id import AssetId
+from proof_of_concept.definitions.identifier import Identifier
 from proof_of_concept.definitions.assets import (
         ComputeAsset, DataAsset, Metadata)
 from proof_of_concept.definitions.interfaces import IStepRunner
@@ -96,7 +96,7 @@ class JobRun(Thread):
                         result_id_hash = id_hashes[result_item]
                         metadata = Metadata(step_subjob, result_item)
                         asset = DataAsset(
-                                AssetId.from_id_hash(result_id_hash),
+                                Identifier.from_id_hash(result_id_hash),
                                 output_value, metadata)
                         self._target_store.store(asset)
 
@@ -188,7 +188,7 @@ class JobRun(Thread):
         return step_input_data
 
     def _retrieve_compute_asset(
-            self, compute_asset_id: AssetId) -> ComputeAsset:
+            self, compute_asset_id: Identifier) -> ComputeAsset:
         asset = self._site_rest_client.retrieve_asset(
                 compute_asset_id.location(), compute_asset_id)
         if not isinstance(asset, ComputeAsset):
@@ -197,7 +197,7 @@ class JobRun(Thread):
 
     def _source(
             self, inp_source: str, id_hashes: Dict[str, str]
-            ) -> Tuple[str, AssetId]:
+            ) -> Tuple[str, Identifier]:
         """Extracts the source from a source description.
 
         If the input is of the form 'step.output', this will return the
@@ -215,7 +215,7 @@ class JobRun(Thread):
         """
         if '.' in inp_source:
             step_name, output_name = inp_source.split('.')
-            return self._sites[step_name], AssetId.from_id_hash(
+            return self._sites[step_name], Identifier.from_id_hash(
                     id_hashes[inp_source])
         else:
             dataset = self._inputs[inp_source]

--- a/proof_of_concept/components/step_runner.py
+++ b/proof_of_concept/components/step_runner.py
@@ -117,8 +117,8 @@ class JobRun(Thread):
             if self._sites[step.name] == self._this_site:
                 # check that we can access the step's inputs
                 for inp_name, inp_src in step.inputs.items():
-                    inp_id = '{}.{}'.format(step.name, inp_name)
-                    inp_perms = perms[inp_id]
+                    inp_item = '{}.{}'.format(step.name, inp_name)
+                    inp_perms = perms[inp_item]
                     if not self._policy_evaluator.may_access(
                             inp_perms, self._this_site):
                         return False
@@ -142,8 +142,8 @@ class JobRun(Thread):
 
                 # check that we can access the step's outputs
                 for outp_name in step.outputs:
-                    outp_id = '{}.{}'.format(step.name, outp_name)
-                    outp_perms = perms[outp_id]
+                    outp_item = '{}.{}'.format(step.name, outp_name)
+                    outp_perms = perms[outp_item]
                     if not self._policy_evaluator.may_access(
                             outp_perms, self._this_site):
                         return False

--- a/proof_of_concept/components/step_runner.py
+++ b/proof_of_concept/components/step_runner.py
@@ -26,7 +26,7 @@ class JobRun(Thread):
     """
     def __init__(
             self, policy_evaluator: PolicyEvaluator,
-            this_site: str,
+            this_site: Identifier,
             registry_client: RegistryClient,
             site_rest_client: SiteRestClient,
             submission: JobSubmission,
@@ -197,7 +197,7 @@ class JobRun(Thread):
 
     def _source(
             self, inp_source: str, id_hashes: Dict[str, str]
-            ) -> Tuple[str, Identifier]:
+            ) -> Tuple[Identifier, Identifier]:
         """Extracts the source from a source description.
 
         If the input is of the form 'step.output', this will return the
@@ -225,7 +225,7 @@ class JobRun(Thread):
 class StepRunner(IStepRunner):
     """A service for running steps of a workflow at a given site."""
     def __init__(
-            self, site: str,
+            self, site: Identifier,
             registry_client: RegistryClient,
             site_rest_client: SiteRestClient,
             policy_evaluator: PolicyEvaluator,

--- a/proof_of_concept/definitions/asset_id.py
+++ b/proof_of_concept/definitions/asset_id.py
@@ -57,16 +57,16 @@ class AssetId(str):
         return str.__new__(cls, seq)        # type: ignore
 
     @classmethod
-    def from_key(cls, key: str) -> 'AssetId':
-        """Creates an AssetId from a key (hash).
+    def from_id_hash(cls, id_hash: str) -> 'AssetId':
+        """Creates an AssetId from an id hash.
 
         Args:
-            key: A hash of a workflow that created this asset.
+            id_hash: A hash of a workflow that created this asset.
 
         Returns:
             The AssetId for the workflow result.
         """
-        return cls(f'hash:{key}')
+        return cls(f'hash:{id_hash}')
 
     def is_primary(self) -> bool:
         """Returns whether this is a primary asset."""

--- a/proof_of_concept/definitions/assets.py
+++ b/proof_of_concept/definitions/assets.py
@@ -59,16 +59,16 @@ class ComputeAsset(Asset):
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Run compute step.
 
-         For now this executes one of several simple
-         algorithms depending on the name attribute.
+        For now this executes one of several simple
+        algorithms depending on the id attribute.
 
         Args:
             inputs: inputs for the compute step, a dictionary keyed by
-            variable name with corresponding values.
+                input name with corresponding values.
 
         Returns:
             outputs: outputs for the compute step, a dictionary keyed by
-                variable name with corresponding values.
+                output name with corresponding values.
 
         """
         outputs = dict()  # type: Dict[str, Any]

--- a/proof_of_concept/definitions/assets.py
+++ b/proof_of_concept/definitions/assets.py
@@ -1,7 +1,7 @@
 """Classes for describing assets."""
 from typing import Any, Dict, Optional, Union
 
-from proof_of_concept.definitions.asset_id import AssetId
+from proof_of_concept.definitions.identifier import Identifier
 from proof_of_concept.definitions.workflows import Job
 
 
@@ -31,7 +31,7 @@ class Metadata:
 class Asset:
     """Asset, a representation of a computation or piece of data."""
 
-    def __init__(self, id: Union[str, AssetId], data: Any,
+    def __init__(self, id: Union[str, Identifier], data: Any,
                  metadata: Optional[Metadata] = None):
         """Constructor.
 
@@ -44,8 +44,8 @@ class Asset:
                 workflow.
 
         """
-        if not isinstance(id, AssetId):
-            id = AssetId(id)
+        if not isinstance(id, Identifier):
+            id = Identifier(id)
         if metadata is None:
             metadata = Metadata(Job.niljob(id), 'dataset')
         self.id = id

--- a/proof_of_concept/definitions/assets.py
+++ b/proof_of_concept/definitions/assets.py
@@ -72,13 +72,13 @@ class ComputeAsset(Asset):
 
         """
         outputs = dict()  # type: Dict[str, Any]
-        if self.id.startswith('id:ddm_ns:software.combine'):
+        if 'combine' in self.id:
             outputs['y'] = [inputs['x1'], inputs['x2']]
-        elif self.id.startswith('id:ddm_ns:software.anonymise'):
+        elif 'anonymise' in self.id:
             outputs['y'] = [x - 10 for x in inputs['x1']]
-        elif self.id.startswith('id:ddm_ns:software.aggregate'):
+        elif 'aggregate' in self.id:
             outputs['y'] = sum(inputs['x1']) / len(inputs['x1'])
-        elif self.id.startswith('id:party2_ns:software.addition'):
+        elif 'addition' in self.id:
             outputs['y'] = inputs['x1'] + inputs['x2']
         else:
             raise RuntimeError('Unknown compute asset')

--- a/proof_of_concept/definitions/identifier.py
+++ b/proof_of_concept/definitions/identifier.py
@@ -77,7 +77,7 @@ class Identifier(str):
         return self.parts[1]
 
     def location(self) -> 'Identifier':
-        """Returns the d of the site storing this asset.
+        """Returns the identifier of the site storing this asset.
 
         Returns:
             A site name.

--- a/proof_of_concept/definitions/identifier.py
+++ b/proof_of_concept/definitions/identifier.py
@@ -33,16 +33,16 @@ class Identifier(str):
         data = str(seq)
 
         if data != '*':
-            parts = data.split(':')
-            if parts[0] not in cls._kinds:
-                raise ValueError(f'Invalid identifier kind {parts[0]}')
+            segments = data.split(':')
+            if segments[0] not in cls._kinds:
+                raise ValueError(f'Invalid identifier kind {segments[0]}')
 
-            if len(parts) != cls._lengths[parts[0]]:
-                raise ValueError(f'Too few or too many parts in {data}')
+            if len(segments) != cls._lengths[segments[0]]:
+                raise ValueError(f'Too few or too many segments in {data}')
 
-            for part in parts:
-                if not cls._part_regex.match(part):
-                    raise ValueError(f'Invalid identifier part {part}')
+            for segment in segments:
+                if not cls._segment_regex.match(segment):
+                    raise ValueError(f'Invalid identifier segment {segment}')
 
         return str.__new__(cls, seq)        # type: ignore
 
@@ -59,8 +59,8 @@ class Identifier(str):
         return cls(f'result:{id_hash}')
 
     @property
-    def parts(self) -> List[str]:
-        """Return the list of parts of this identifier."""
+    def segments(self) -> List[str]:
+        """Return the list of segments of this identifier."""
         return self.split(':')
 
     def namespace(self) -> str:
@@ -72,9 +72,9 @@ class Identifier(str):
         Raises:
             RuntimeError: If this is not a primary asset.
         """
-        if self.parts[0] == 'result':
+        if self.segments[0] == 'result':
             raise RuntimeError('Results do not have a namespace')
-        return self.parts[1]
+        return self.segments[1]
 
     def location(self) -> 'Identifier':
         """Returns the identifier of the site storing this asset.
@@ -85,10 +85,10 @@ class Identifier(str):
         Raises:
             RuntimeError: If this is not a concrete asset.
         """
-        if self.parts[0] != 'asset':
+        if self.segments[0] != 'asset':
             raise RuntimeError(
                     'Location requested of non-concrete asset {self}')
-        return Identifier(f'site:{self.parts[3]}:{self.parts[4]}')
+        return Identifier(f'site:{self.segments[3]}:{self.segments[4]}')
 
     _kinds = (
         'party', 'party_collection', 'site', 'asset', 'asset_collection',
@@ -98,4 +98,4 @@ class Identifier(str):
             'party': 3, 'party_collection': 3, 'site': 3, 'asset': 5,
             'asset_collection': 3, 'result': 2}
 
-    _part_regex = re.compile('[a-zA-Z0-9_.-]*')
+    _segment_regex = re.compile('[a-zA-Z0-9_.-]*')

--- a/proof_of_concept/definitions/identifier.py
+++ b/proof_of_concept/definitions/identifier.py
@@ -15,7 +15,7 @@ class Identifier(str):
     5. asset_collection:<namespace>:<name>
     6. result:<id_hash>
 
-    This class also accepts a single asterisk an an identifier, as it
+    This class also accepts a single asterisk as an identifier, as it
     is used as a wildcard in rules.
 
     See the Terminology section of the documentation for details.

--- a/proof_of_concept/definitions/identifier.py
+++ b/proof_of_concept/definitions/identifier.py
@@ -2,7 +2,7 @@
 from typing import Any, cast, Type
 
 
-class AssetId(str):
+class Identifier(str):
     """An id of an asset.
 
     An Asset id is a string of any of the following forms:
@@ -18,7 +18,7 @@ class AssetId(str):
     image) associated with them, which is stored at <site>.
 
     Form 2 is used for asset collections. These are named (with an
-    AssetId) collections of assets created implicitly by
+    Identifier) collections of assets created implicitly by
     InAssetCollection rules. These are also considered primary assets,
     but they are abstract, not concrete, because there is no
     downloadable object associated with them.
@@ -30,8 +30,8 @@ class AssetId(str):
     id does not specify their location.
 
     """
-    def __new__(cls: Type['AssetId'], seq: Any) -> 'AssetId':
-        """Create an AssetId.
+    def __new__(cls: Type['Identifier'], seq: Any) -> 'Identifier':
+        """Create an Identifier.
 
         Args:
             seq: Contents, will be converted to a string using str(),
@@ -57,14 +57,14 @@ class AssetId(str):
         return str.__new__(cls, seq)        # type: ignore
 
     @classmethod
-    def from_id_hash(cls, id_hash: str) -> 'AssetId':
-        """Creates an AssetId from an id hash.
+    def from_id_hash(cls, id_hash: str) -> 'Identifier':
+        """Creates an Identifier from an id hash.
 
         Args:
             id_hash: A hash of a workflow that created this asset.
 
         Returns:
-            The AssetId for the workflow result.
+            The Identifier for the workflow result.
         """
         return cls(f'hash:{id_hash}')
 

--- a/proof_of_concept/definitions/interfaces.py
+++ b/proof_of_concept/definitions/interfaces.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from typing import Generic, Iterable, Set, Type, TypeVar
 
-from proof_of_concept.definitions.asset_id import AssetId
+from proof_of_concept.definitions.identifier import Identifier
 from proof_of_concept.definitions.assets import Asset
 from proof_of_concept.definitions.policy import Rule
 from proof_of_concept.definitions.workflows import JobSubmission
@@ -68,7 +68,7 @@ class IAssetStore:
         """
         raise NotImplementedError()
 
-    def retrieve(self, asset_id: AssetId, requester: str
+    def retrieve(self, asset_id: Identifier, requester: str
                  ) -> Asset:
         """Retrieves an asset.
 

--- a/proof_of_concept/definitions/registry.py
+++ b/proof_of_concept/definitions/registry.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
+from proof_of_concept.definitions.identifier import Identifier
+
 
 class RegisteredObject:
     """Base class for objects in the registry."""
@@ -13,32 +15,32 @@ class PartyDescription(RegisteredObject):
     """Describes a Party to the rest of the DDM.
 
     Attributes:
-        name: Name of the party.
+        id: Id of the party.
         public_key: The party's public key for signing rules.
 
     """
-    def __init__(self, name: str, public_key: RSAPublicKey) -> None:
+    def __init__(self, party_id: Identifier, public_key: RSAPublicKey) -> None:
         """Create a PartyDescription.
 
         Args:
-            name: Name of the party.
+            party_id: ID of the party.
             public_key: The party's public key for signing rules.
         """
-        self.name = name
+        self.id = party_id
         self.public_key = public_key
 
     def __repr__(self) -> str:
         """Returns a string representation of the object."""
-        return f'PartyDescription({self.name})'
+        return f'PartyDescription({self.id})'
 
 
 class SiteDescription(RegisteredObject):
     """Describes a site to the rest of the DDM.
 
     Attributes:
-        name: Name of the site.
-        owner_name: Name of the party which owns this site.
-        admin_name: Name of the party which administrates this site.
+        id: ID of the site.
+        owner_id: The party which owns this site.
+        admin_id: The party which administrates this site.
         endpoint: This site's REST endpoint.
         runner: Whether the site has a runner.
         store: Whether the site has a store.
@@ -48,9 +50,9 @@ class SiteDescription(RegisteredObject):
     """
     def __init__(
             self,
-            name: str,
-            owner_name: str,
-            admin_name: str,
+            site_id: Identifier,
+            owner_id: Identifier,
+            admin_id: Identifier,
             endpoint: str,
             runner: bool,
             store: bool,
@@ -59,9 +61,10 @@ class SiteDescription(RegisteredObject):
         """Create a SiteDescription.
 
         Args:
-            name: Name of the site.
-            owner_name: Name of the party which owns this site.
-            admin_name: Name of the party which administrates this site.
+            site_id: Identifier of the site.
+            owner_id: Identifier of the party which owns this site.
+            admin_id: Identifier of the party which administrates this
+                site.
             endpoint: URL of the REST endpoint of this site.
             runner: Whether the site has a runner.
             store: Whether the site has a store.
@@ -69,9 +72,9 @@ class SiteDescription(RegisteredObject):
                 server, if any.
 
         """
-        self.name = name
-        self.owner_name = owner_name
-        self.admin_name = admin_name
+        self.id = site_id
+        self.owner_id = owner_id
+        self.admin_id = admin_id
         self.endpoint = endpoint
         self.runner = runner
         self.store = store
@@ -82,4 +85,4 @@ class SiteDescription(RegisteredObject):
 
     def __repr__(self) -> str:
         """Returns a string representation of the object."""
-        return f'SiteDescription({self.name})'
+        return f'SiteDescription({self.id})'

--- a/proof_of_concept/definitions/workflows.py
+++ b/proof_of_concept/definitions/workflows.py
@@ -2,7 +2,7 @@
 from hashlib import sha256
 from typing import Dict, List, Mapping, Set, Tuple, Union
 
-from proof_of_concept.definitions.asset_id import AssetId
+from proof_of_concept.definitions.identifier import Identifier
 
 
 class WorkflowStep:
@@ -10,7 +10,7 @@ class WorkflowStep:
     def __init__(
             self, name: str,
             inputs: Dict[str, str], outputs: List[str],
-            compute_asset_id: Union[str, AssetId]
+            compute_asset_id: Union[str, Identifier]
             ) -> None:
         """Create a WorkflowStep.
 
@@ -25,8 +25,8 @@ class WorkflowStep:
         self.name = name
         self.inputs = inputs
         self.outputs = outputs
-        if not isinstance(compute_asset_id, AssetId):
-            compute_asset_id = AssetId(compute_asset_id)
+        if not isinstance(compute_asset_id, Identifier):
+            compute_asset_id = Identifier(compute_asset_id)
         self.compute_asset_id = compute_asset_id
 
         self._validate()
@@ -167,7 +167,8 @@ class Workflow:
 class Job:
     """Represents a job to the system from a user."""
     def __init__(
-            self, workflow: Workflow, inputs: Mapping[str, Union[str, AssetId]]
+            self, workflow: Workflow,
+            inputs: Mapping[str, Union[str, Identifier]]
             ) -> None:
         """Create a job.
 
@@ -178,7 +179,7 @@ class Job:
         """
         self.workflow = workflow
         self.inputs = {
-                inp: aid if isinstance(aid, AssetId) else AssetId(aid)
+                inp: aid if isinstance(aid, Identifier) else Identifier(aid)
                 for inp, aid in inputs.items()}
 
     def __repr__(self) -> str:
@@ -187,7 +188,7 @@ class Job:
                 self.inputs, self.workflow)
 
     @staticmethod
-    def niljob(asset_id: AssetId) -> 'Job':
+    def niljob(asset_id: Identifier) -> 'Job':
         """Returns a zero-step job for a dataset.
 
         Args:

--- a/proof_of_concept/definitions/workflows.py
+++ b/proof_of_concept/definitions/workflows.py
@@ -187,15 +187,15 @@ class Job:
                 self.inputs, self.workflow)
 
     @staticmethod
-    def niljob(key: AssetId) -> 'Job':
+    def niljob(asset_id: AssetId) -> 'Job':
         """Returns a zero-step job for a dataset.
 
         Args:
-            key: The key identifying the dataset.
+            asset_id: The dataset to represent.
 
         The job will have no steps, and a single input named `dataset`.
         """
-        return Job(Workflow(['dataset'], {}, []), {'dataset': key})
+        return Job(Workflow(['dataset'], {}, []), {'dataset': asset_id})
 
     def subjob(
             self, step: WorkflowStep) -> 'Job':
@@ -215,67 +215,67 @@ class Job:
                 if wf_inp in sub_wf.inputs}
         return Job(sub_wf, inputs)
 
-    def keys(self) -> Dict[str, str]:
-        """Calculates hash-keys of all items in the job's workflow.
+    def id_hashes(self) -> Dict[str, str]:
+        """Calculates id hashes of all items in the job's workflow.
 
         Returns:
-            A dict mapping workflow items to their key.
+            A dict mapping workflow items to their id hash.
         """
         class DependencyMissing(RuntimeError):
             pass
 
-        def prop_input_keys(item_keys: Dict[str, str]) -> None:
+        def prop_input_id_hashes(item_id_hashes: Dict[str, str]) -> None:
             for inp_name, inp_src in self.inputs.items():
-                inp_hash = sha256()
-                inp_hash.update(inp_src.encode('utf-8'))
-                item_keys[inp_name] = inp_hash.hexdigest()
+                inp_id_hash = sha256()
+                inp_id_hash.update(inp_src.encode('utf-8'))
+                item_id_hashes[inp_name] = inp_id_hash.hexdigest()
 
         def prop_input_sources(
-                item_keys: Dict[str, str], step: WorkflowStep) -> None:
+                item_id_hashes: Dict[str, str], step: WorkflowStep) -> None:
             for inp_name, inp_src in step.inputs.items():
                 inp_item = '{}.{}'.format(step.name, inp_name)
-                if inp_item not in item_keys:
-                    if inp_src not in item_keys:
+                if inp_item not in item_id_hashes:
+                    if inp_src not in item_id_hashes:
                         raise DependencyMissing()
-                    item_keys[inp_item] = item_keys[inp_src]
+                    item_id_hashes[inp_item] = item_id_hashes[inp_src]
 
         def calc_step_outputs(
-                item_keys: Dict[str, str], step: WorkflowStep) -> None:
+                item_id_hashes: Dict[str, str], step: WorkflowStep) -> None:
             step_hash = sha256()
             for inp_name in sorted(step.inputs):
                 inp_item = '{}.{}'.format(step.name, inp_name)
                 step_hash.update(
-                        item_keys[inp_item].encode('utf-8'))
+                        item_id_hashes[inp_item].encode('utf-8'))
             step_hash.update(
                     step.compute_asset_id.encode('utf-8'))
             for outp_name in step.outputs:
                 outp_item = '{}.{}'.format(step.name, outp_name)
                 outp_hash = step_hash.copy()
                 outp_hash.update(outp_name.encode('utf-8'))
-                item_keys[outp_item] = outp_hash.hexdigest()
+                item_id_hashes[outp_item] = outp_hash.hexdigest()
 
-        def set_workflow_outputs_keys(
-                item_keys: Dict[str, str],
+        def set_workflow_outputs_id_hashes(
+                item_id_hashes: Dict[str, str],
                 outputs: Dict[str, str]) -> None:
             for outp_name, outp_src in outputs.items():
-                item_keys[outp_name] = item_keys[outp_src]
+                item_id_hashes[outp_name] = item_id_hashes[outp_src]
 
-        item_keys = dict()      # type: Dict[str, str]
-        prop_input_keys(item_keys)
+        item_id_hashes = dict()      # type: Dict[str, str]
+        prop_input_id_hashes(item_id_hashes)
 
         steps_done = set()      # type: Set[str]
         while len(steps_done) < len(self.workflow.steps):
             for step in self.workflow.steps.values():
                 if step.name not in steps_done:
                     try:
-                        prop_input_sources(item_keys, step)
-                        calc_step_outputs(item_keys, step)
+                        prop_input_sources(item_id_hashes, step)
+                        calc_step_outputs(item_id_hashes, step)
                         steps_done.add(step.name)
                     except DependencyMissing:
                         continue
 
-        set_workflow_outputs_keys(item_keys, self.workflow.outputs)
-        return item_keys
+        set_workflow_outputs_id_hashes(item_id_hashes, self.workflow.outputs)
+        return item_id_hashes
 
 
 class Plan:

--- a/proof_of_concept/definitions/workflows.py
+++ b/proof_of_concept/definitions/workflows.py
@@ -289,7 +289,7 @@ class Plan:
                 site's id.
 
     """
-    def __init__(self, step_sites: Dict[str, str]) -> None:
+    def __init__(self, step_sites: Dict[str, Identifier]) -> None:
         """Create a plan.
 
         Args:

--- a/proof_of_concept/policy/evaluation.py
+++ b/proof_of_concept/policy/evaluation.py
@@ -244,11 +244,11 @@ class PermissionCalculator:
                 available.
             """
             for inp, inp_source in step.inputs.items():
-                inp_key = '{}.{}'.format(step.name, inp)
-                if inp_key not in permissions:
+                inp_item = '{}.{}'.format(step.name, inp)
+                if inp_item not in permissions:
                     if inp_source not in permissions:
                         raise InputNotAvailable()
-                    permissions[inp_key] = permissions[inp_source]
+                    permissions[inp_item] = permissions[inp_source]
 
         def calc_step_permissions(
                 permissions: Dict[str, Permissions],
@@ -278,15 +278,15 @@ class PermissionCalculator:
             """
             input_perms = list()     # type: List[Permissions]
             for inp in step.inputs:
-                inp_key = '{}.{}'.format(step.name, inp)
-                input_perms.append(permissions[inp_key])
+                inp_item = '{}.{}'.format(step.name, inp)
+                input_perms.append(permissions[inp_item])
 
             perms = self._policy_evaluator.propagate_permissions(
                         input_perms, step.compute_asset_id)
 
             for output in step.outputs:
-                output_key = '{}.{}'.format(step.name, output)
-                permissions[output_key] = perms
+                output_item = '{}.{}'.format(step.name, output)
+                permissions[output_item] = perms
 
         def set_workflow_outputs_permissions(
                 permissions: Dict[str, Permissions],

--- a/proof_of_concept/policy/evaluation.py
+++ b/proof_of_concept/policy/evaluation.py
@@ -1,7 +1,7 @@
 """Components for evaluating workflow permissions."""
 from typing import Dict, List, Set, Type
 
-from proof_of_concept.definitions.asset_id import AssetId
+from proof_of_concept.definitions.identifier import Identifier
 from proof_of_concept.definitions.interfaces import IPolicyCollection
 from proof_of_concept.definitions.workflows import Job, Workflow, WorkflowStep
 from proof_of_concept.policy.rules import (
@@ -14,7 +14,7 @@ class Permissions:
     def __init__(self) -> None:
         """Creates Permissions that do not allow access."""
         # friend PolicyEvaluator
-        self._sets = list()     # type: List[Set[AssetId]]
+        self._sets = list()     # type: List[Set[Identifier]]
 
     def __str__(self) -> str:
         """Returns a string representationf this object."""
@@ -35,7 +35,7 @@ class PolicyEvaluator:
         """
         self._policy_collection = policy_collection
 
-    def permissions_for_asset(self, asset: AssetId) -> Permissions:
+    def permissions_for_asset(self, asset: Identifier) -> Permissions:
         """Returns permissions for the given asset.
 
         This must be a primary asset, not an intermediate result, as
@@ -51,7 +51,7 @@ class PolicyEvaluator:
     def propagate_permissions(
             self,
             input_permissions: List[Permissions],
-            compute_asset: AssetId
+            compute_asset: Identifier
             ) -> Permissions:
         """Determines access for the result of an operation.
 
@@ -96,7 +96,7 @@ class PolicyEvaluator:
             permissions: Permissions for the asset to check.
             site: A site which needs access.
         """
-        def matches_one(asset_set: Set[AssetId], site: str) -> bool:
+        def matches_one(asset_set: Set[Identifier], site: str) -> bool:
             for asset in asset_set:
                 for rule in self._policy_collection.policies():
                     if isinstance(rule, MayAccess):
@@ -130,7 +130,7 @@ class PolicyEvaluator:
                             new_parties.append(rule.collection)
         return cur_parties
 
-    def _equivalent_assets(self, asset: AssetId) -> Set[AssetId]:
+    def _equivalent_assets(self, asset: Identifier) -> Set[Identifier]:
         """Returns all the assets whose rules apply to an asset.
 
         These are the asset itself, and all assets that are asset
@@ -139,7 +139,7 @@ class PolicyEvaluator:
         Args:
             asset: The asset to find equivalents for.
         """
-        cur_assets = set()     # type: Set[AssetId]
+        cur_assets = set()     # type: Set[Identifier]
         new_assets = {asset}
         while new_assets:
             cur_assets |= new_assets
@@ -150,11 +150,12 @@ class PolicyEvaluator:
                         if rule.asset == asset:
                             if rule.collection not in cur_assets:
                                 new_assets.add(rule.collection)
-        cur_assets.add(AssetId('*'))
+        cur_assets.add(Identifier('*'))
         return cur_assets
 
     def _resultofin_rules(
-            self, typ: Type, asset_set: Set[AssetId], compute_asset: AssetId
+            self, typ: Type, asset_set: Set[Identifier],
+            compute_asset: Identifier
             ) -> List[ResultOfIn]:
         """Returns all ResultOfIn rules that apply to these assets.
 
@@ -169,7 +170,7 @@ class PolicyEvaluator:
             asset_set: Set of data assets to match rules to.
             compute_asset: Compute asset to match rules to.
         """
-        def rules_for_asset(asset: AssetId) -> List[ResultOfIn]:
+        def rules_for_asset(asset: Identifier) -> List[ResultOfIn]:
             """Gets all matching rules for the given single asset."""
             result = list()     # type: List[ResultOfIn]
             assets = self._equivalent_assets(asset)

--- a/proof_of_concept/policy/rules.py
+++ b/proof_of_concept/policy/rules.py
@@ -1,7 +1,7 @@
 """Classes representing rules."""
 from typing import Union
 
-from proof_of_concept.definitions.assets import AssetId
+from proof_of_concept.definitions.assets import Identifier
 from proof_of_concept.definitions.policy import Rule
 
 
@@ -12,7 +12,8 @@ class InAssetCollection(Rule):
     the Asset.
     """
     def __init__(
-            self, asset: Union[str, AssetId], collection: Union[str, AssetId]
+            self, asset: Union[str, Identifier],
+            collection: Union[str, Identifier]
             ) -> None:
         """Create an InAssetCollection rule.
 
@@ -20,9 +21,11 @@ class InAssetCollection(Rule):
             asset: The asset to put into the collection.
             collection: The collection to put it into.
         """
-        self.asset = asset if isinstance(asset, AssetId) else AssetId(asset)
-        if not isinstance(collection, AssetId):
-            collection = AssetId(collection)
+        if not isinstance(asset, Identifier):
+            asset = Identifier(asset)
+        self.asset = asset
+        if not isinstance(collection, Identifier):
+            collection = Identifier(collection)
         self.collection = collection
 
     def __repr__(self) -> str:
@@ -43,7 +46,7 @@ class InAssetCollection(Rule):
 
 class InPartyCollection(Rule):
     """Says that Party party is in PartyCollection collection."""
-    def __init__(self, party: str, collection: Union[str, AssetId]) -> None:
+    def __init__(self, party: str, collection: Union[str, Identifier]) -> None:
         """Create an InPartyCollection rule.
 
         Args:
@@ -51,8 +54,8 @@ class InPartyCollection(Rule):
             collection: The collection it is in.
         """
         self.party = party
-        if not isinstance(collection, AssetId):
-            collection = AssetId(collection)
+        if not isinstance(collection, Identifier):
+            collection = Identifier(collection)
         self.collection = collection
 
     def __repr__(self) -> str:
@@ -73,7 +76,7 @@ class InPartyCollection(Rule):
 
 class MayAccess(Rule):
     """Says that Site site may access Asset asset."""
-    def __init__(self, site: str, asset: Union[str, AssetId]) -> None:
+    def __init__(self, site: str, asset: Union[str, Identifier]) -> None:
         """Create a MayAccess rule.
 
         Args:
@@ -81,7 +84,9 @@ class MayAccess(Rule):
             asset: The asset that may be accessed.
         """
         self.site = site
-        self.asset = asset if isinstance(asset, AssetId) else AssetId(asset)
+        if not isinstance(asset, Identifier):
+            asset = Identifier(asset)
+        self.asset = asset
 
     def __repr__(self) -> str:
         """Return a string representation of this rule."""
@@ -108,9 +113,9 @@ class ResultOfIn(Rule):
     """
     def __init__(
             self,
-            data_asset: Union[str, AssetId],
-            compute_asset: Union[str, AssetId],
-            collection: AssetId
+            data_asset: Union[str, Identifier],
+            compute_asset: Union[str, Identifier],
+            collection: Identifier
             ) -> None:
         """Create a ResultOfIn rule.
 
@@ -119,11 +124,11 @@ class ResultOfIn(Rule):
             compute_asset: The compute asset used to process the data.
             collection: The output collection.
         """
-        if not isinstance(data_asset, AssetId):
-            data_asset = AssetId(data_asset)
+        if not isinstance(data_asset, Identifier):
+            data_asset = Identifier(data_asset)
 
-        if not isinstance(compute_asset, AssetId):
-            compute_asset = AssetId(compute_asset)
+        if not isinstance(compute_asset, Identifier):
+            compute_asset = Identifier(compute_asset)
 
         self.data_asset = data_asset
         self.compute_asset = compute_asset

--- a/proof_of_concept/policy/rules.py
+++ b/proof_of_concept/policy/rules.py
@@ -1,7 +1,7 @@
 """Classes representing rules."""
 from typing import Union
 
-from proof_of_concept.definitions.assets import Identifier
+from proof_of_concept.definitions.identifier import Identifier
 from proof_of_concept.definitions.policy import Rule
 
 
@@ -46,13 +46,18 @@ class InAssetCollection(Rule):
 
 class InPartyCollection(Rule):
     """Says that Party party is in PartyCollection collection."""
-    def __init__(self, party: str, collection: Union[str, Identifier]) -> None:
+    def __init__(
+            self, party: Union[str, Identifier],
+            collection: Union[str, Identifier]
+            ) -> None:
         """Create an InPartyCollection rule.
 
         Args:
             party: A party.
             collection: The collection it is in.
         """
+        if not isinstance(party, Identifier):
+            party = Identifier(party)
         self.party = party
         if not isinstance(collection, Identifier):
             collection = Identifier(collection)
@@ -76,14 +81,16 @@ class InPartyCollection(Rule):
 
 class MayAccess(Rule):
     """Says that Site site may access Asset asset."""
-    def __init__(self, site: str, asset: Union[str, Identifier]) -> None:
+    def __init__(
+            self, site: Union[str, Identifier], asset: Union[str, Identifier]
+            ) -> None:
         """Create a MayAccess rule.
 
         Args:
             site: The site that may access.
             asset: The asset that may be accessed.
         """
-        self.site = site
+        self.site = site if isinstance(site, Identifier) else Identifier(site)
         if not isinstance(asset, Identifier):
             asset = Identifier(asset)
         self.asset = asset
@@ -115,7 +122,7 @@ class ResultOfIn(Rule):
             self,
             data_asset: Union[str, Identifier],
             compute_asset: Union[str, Identifier],
-            collection: Identifier
+            collection: Union[str, Identifier]
             ) -> None:
         """Create a ResultOfIn rule.
 
@@ -129,6 +136,9 @@ class ResultOfIn(Rule):
 
         if not isinstance(compute_asset, Identifier):
             compute_asset = Identifier(compute_asset)
+
+        if not isinstance(collection, Identifier):
+            collection = Identifier(collection)
 
         self.data_asset = data_asset
         self.compute_asset = compute_asset

--- a/proof_of_concept/registry/registry.py
+++ b/proof_of_concept/registry/registry.py
@@ -2,7 +2,7 @@
 import logging
 from typing import Any, Dict, Optional, Type, TypeVar
 
-from proof_of_concept.definitions.assets import Identifier
+from proof_of_concept.definitions.identifier import Identifier
 from proof_of_concept.definitions.interfaces import IAssetStore
 from proof_of_concept.definitions.registry import (
         PartyDescription, RegisteredObject, SiteDescription)

--- a/proof_of_concept/registry/registry.py
+++ b/proof_of_concept/registry/registry.py
@@ -2,7 +2,7 @@
 import logging
 from typing import Any, Dict, Optional, Type, TypeVar
 
-from proof_of_concept.definitions.assets import AssetId
+from proof_of_concept.definitions.assets import Identifier
 from proof_of_concept.definitions.interfaces import IAssetStore
 from proof_of_concept.definitions.registry import (
         PartyDescription, RegisteredObject, SiteDescription)
@@ -25,7 +25,7 @@ class Registry:
     """
     def __init__(self) -> None:
         """Create a new registry."""
-        self._asset_locations = dict()           # type: Dict[AssetId, str]
+        self._asset_locations = dict()           # type: Dict[Identifier, str]
 
         archive = ReplicableArchive[RegisteredObject]()
         self.store = RegistryStore(archive, 0.1)

--- a/proof_of_concept/registry/registry.py
+++ b/proof_of_concept/registry/registry.py
@@ -37,20 +37,20 @@ class Registry:
         Args:
             description: A description of the party
         """
-        if self._in_store(PartyDescription, 'name', description.name):
+        if self._in_store(PartyDescription, 'id', description.id):
             raise RuntimeError(
-                    f'There is already a party called {description.name}')
+                    f'There is already a party called {description.id}')
 
         self.store.insert(description)
         logger.info(f'Registered party {description}')
 
-    def deregister_party(self, name: str) -> None:
+    def deregister_party(self, party_id: Identifier) -> None:
         """Deregister a party with the DDM.
 
         Args:
-            name: Name of the party to deregister.
+            party_id: Identifier of the party to deregister.
         """
-        description = self._get_object(PartyDescription, 'name', name)
+        description = self._get_object(PartyDescription, 'id', party_id)
         if description is None:
             raise KeyError('Party not found')
         self.store.delete(description)
@@ -62,30 +62,30 @@ class Registry:
             description: Description of the site.
 
         """
-        if self._in_store(SiteDescription, 'name', description.name):
+        if self._in_store(SiteDescription, 'id', description.id):
             raise RuntimeError(
-                    f'There is already a site called {description.name}')
+                    f'There is already a site called {description.id}')
 
         owner = self._get_object(
-                PartyDescription, 'name', description.owner_name)
+                PartyDescription, 'id', description.owner_id)
         if owner is None:
-            raise RuntimeError(f'Party {description.owner_name} not found')
+            raise RuntimeError(f'Party {description.owner_id} not found')
 
         admin = self._get_object(
-                PartyDescription, 'name', description.admin_name)
+                PartyDescription, 'id', description.admin_id)
         if admin is None:
-            raise RuntimeError(f'Party {description.admin_name} not found')
+            raise RuntimeError(f'Party {description.admin_id} not found')
 
         self.store.insert(description)
         logger.info(f'{self} Registered site {description}')
 
-    def deregister_site(self, name: str) -> None:
+    def deregister_site(self, site_id: Identifier) -> None:
         """Deregister a site with the DDM.
 
         Args:
-            name: Name of the site to deregister.
+            site_id: Identifer of the site to deregister.
         """
-        description = self._get_object(SiteDescription, 'name', name)
+        description = self._get_object(SiteDescription, 'id', site_id)
         if description is None:
             raise KeyError('Site not found')
         self.store.delete(description)

--- a/proof_of_concept/rest/client.py
+++ b/proof_of_concept/rest/client.py
@@ -30,7 +30,7 @@ class SiteRestClient:
 
     def retrieve_asset(self, site_name: str, asset_id: AssetId
                        ) -> Asset:
-        """Obtains a data item from a store."""
+        """Obtains an asset from a store."""
         try:
             site = self._registry_client.get_site_by_name(site_name)
         except KeyError:

--- a/proof_of_concept/rest/client.py
+++ b/proof_of_concept/rest/client.py
@@ -28,13 +28,13 @@ class SiteRestClient:
         self._site_validator = site_validator
         self._registry_client = registry_client
 
-    def retrieve_asset(self, site_name: str, asset_id: Identifier
+    def retrieve_asset(self, site_id: Identifier, asset_id: Identifier
                        ) -> Asset:
         """Obtains an asset from a store."""
         try:
-            site = self._registry_client.get_site_by_name(site_name)
+            site = self._registry_client.get_site_by_id(site_id)
         except KeyError:
-            raise RuntimeError(f'Site or store at site {site_name} not found')
+            raise RuntimeError(f'Site or store at site {site_id} not found')
 
         if site.store is not None:
             safe_asset_id = quote(asset_id, safe='')
@@ -50,22 +50,23 @@ class SiteRestClient:
             self._site_validator.validate('Asset', asset_json)
             return deserialize(Asset, asset_json)
 
-        raise ValueError(f'Site {site_name} does not have a store')
+        raise ValueError(f'Site {site_id} does not have a store')
 
-    def submit_job(self, site_name: str, submission: JobSubmission) -> None:
+    def submit_job(
+            self, site_id: Identifier, submission: JobSubmission) -> None:
         """Submits a job for execution to a local runner.
 
         Args:
-            site_name: The site to submit to.
+            site_id: The site to submit to.
             submission: The job submision to send.
 
         """
         try:
-            site = self._registry_client.get_site_by_name(site_name)
+            site = self._registry_client.get_site_by_id(site_id)
         except KeyError:
-            raise RuntimeError(f'Site or runner at site {site_name} not found')
+            raise RuntimeError(f'Site or runner at site {site_id} not found')
 
         if site.runner:
             requests.post(f'{site.endpoint}/jobs', json=serialize(submission))
         else:
-            raise ValueError(f'Site {site_name} does not have a runner')
+            raise ValueError(f'Site {site_id} does not have a runner')

--- a/proof_of_concept/rest/client.py
+++ b/proof_of_concept/rest/client.py
@@ -2,7 +2,7 @@
 import requests
 from urllib.parse import quote
 
-from proof_of_concept.definitions.asset_id import AssetId
+from proof_of_concept.definitions.identifier import Identifier
 from proof_of_concept.definitions.assets import Asset
 from proof_of_concept.definitions.workflows import JobSubmission
 from proof_of_concept.rest.serialization import deserialize, serialize
@@ -28,7 +28,7 @@ class SiteRestClient:
         self._site_validator = site_validator
         self._registry_client = registry_client
 
-    def retrieve_asset(self, site_name: str, asset_id: AssetId
+    def retrieve_asset(self, site_name: str, asset_id: Identifier
                        ) -> Asset:
         """Obtains an asset from a store."""
         try:

--- a/proof_of_concept/rest/ddm_site.py
+++ b/proof_of_concept/rest/ddm_site.py
@@ -8,7 +8,7 @@ from wsgiref.simple_server import WSGIRequestHandler, WSGIServer
 from falcon import App, HTTP_200, HTTP_400, HTTP_404, Request, Response
 import ruamel.yaml as yaml
 
-from proof_of_concept.definitions.asset_id import AssetId
+from proof_of_concept.definitions.identifier import Identifier
 from proof_of_concept.definitions.interfaces import IAssetStore, IStepRunner
 from proof_of_concept.definitions.policy import Rule
 from proof_of_concept.definitions.workflows import JobSubmission
@@ -53,7 +53,7 @@ class AssetAccessHandler:
                     f' {request.params["requester"]}')
             try:
                 asset = self._store.retrieve(
-                        AssetId(asset_id), request.params['requester'])
+                        Identifier(asset_id), request.params['requester'])
                 response.status = HTTP_200
                 response.media = serialize(asset)
             except KeyError:

--- a/proof_of_concept/rest/registry.py
+++ b/proof_of_concept/rest/registry.py
@@ -10,6 +10,7 @@ from falcon import (
         Response)
 import ruamel.yaml as yaml
 
+from proof_of_concept.definitions.identifier import Identifier
 from proof_of_concept.definitions.registry import (
         PartyDescription, RegisteredObject, SiteDescription)
 from proof_of_concept.registry.registry import Registry
@@ -60,17 +61,17 @@ class PartyRegistrationHandler:
             response.body = 'Party already exists'
 
     def on_delete(
-            self, request: Request, response: Response, name: str) -> None:
+            self, request: Request, response: Response, id: str) -> None:
         """Handle a party deregistration request.
 
         Args:
             request: The submitted request.
             response: A response object to configure
-            name: Name of the party to deregister.
+            id: Identifier of the party to deregister.
 
         """
         try:
-            self._registry.deregister_party(name)
+            self._registry.deregister_party(Identifier(id))
             response.status = HTTP_200
             response.body = 'Deleted'
         except KeyError as e:
@@ -115,17 +116,17 @@ class SiteRegistrationHandler:
             response.body = 'Site already exists'
 
     def on_delete(
-            self, request: Request, response: Response, name: str) -> None:
+            self, request: Request, response: Response, id: str) -> None:
         """Handle a site deregistration request.
 
         Args:
             request: The submitted request.
             response: A response object to configure.
-            name: Name of the site to deregister.
+            id: Identifier of the site to deregister.
 
         """
         try:
-            self._registry.deregister_site(name)
+            self._registry.deregister_site(Identifier(id))
             response.status = HTTP_200
             response.body = 'Deleted'
         except KeyError as e:
@@ -158,11 +159,11 @@ class RegistryRestApi:
 
         party_registration = PartyRegistrationHandler(registry, validator)
         self.app.add_route('/parties', party_registration)
-        self.app.add_route('/parties/{name}', party_registration)
+        self.app.add_route('/parties/{id}', party_registration)
 
         site_registration = SiteRegistrationHandler(registry, validator)
         self.app.add_route('/sites', site_registration)
-        self.app.add_route('/sites/{name}', site_registration)
+        self.app.add_route('/sites/{id}', site_registration)
 
         registry_replication = ReplicationHandler[RegisteredObject](
                 registry.store)

--- a/proof_of_concept/rest/registry_api.yaml
+++ b/proof_of_concept/rest/registry_api.yaml
@@ -32,7 +32,7 @@ paths:
                 description: An error message
                 type: string
         "409":
-          description: A party with this name was already registered
+          description: A party with this id was already registered
           content:
             text/plain:
               schema:
@@ -45,15 +45,15 @@ paths:
               schema:
                 type: string
 
-  /parties/{name}:
+  /parties/{id}:
     delete:
       summary: Deregister a party
       operationId: deregisterParty
       parameters:
-        - name: name
+        - name: id
           in: path
           required: true
-          description: The name of the asset to deregister
+          description: The id of the asset to deregister
           schema:
             type: string
       responses:
@@ -105,7 +105,7 @@ paths:
                 description: An error message
                 type: string
         "409":
-          description: A site with this name was already registered
+          description: A site with this id was already registered
           content:
             text/plain:
               schema:
@@ -118,15 +118,15 @@ paths:
               schema:
                 type: string
 
-  /sites/{name}:
+  /sites/{id}:
     delete:
       summary: Deregister a site
       operationId: deregisterSite
       parameters:
-        - name: name
+        - name: id
           in: path
           required: true
-          description: The name of the site to deregister
+          description: The id of the site to deregister
           schema:
             type: string
       responses:
@@ -190,11 +190,11 @@ components:
     Party:
       type: object
       required:
-        - name
+        - id
         - public_key
       properties:
-        name:
-          description: Name of the party
+        id:
+          description: Identifier of the party
           type: string
         public_key:
           description: The party's PEM-encoded RSA public key
@@ -203,22 +203,22 @@ components:
     Site:
       type: object
       required:
-        - name
-        - owner_name
-        - admin_name
+        - id
+        - owner_id
+        - admin_id
         - endpoint
         - runner
         - store
         - namespace
       properties:
-        name:
-          description: Name of the site
+        id:
+          description: Identifier of the site
           type: string
-        owner_name:
-          description: Name of the party which owns this site
+        owner_id:
+          description: Identifier of the party which owns this site
           type: string
-        admin_name:
-          description: Name of the party which administrates this site
+        admin_id:
+          description: Identifier of the party which administrates this site
           type: string
         endpoint:
           description: >-

--- a/proof_of_concept/rest/serialization.py
+++ b/proof_of_concept/rest/serialization.py
@@ -49,24 +49,24 @@ def _serialize_party_description(party_desc: PartyDescription) -> JSON:
             ).decode('ascii')
 
     return {
-            'name': party_desc.name,
+            'id': party_desc.id,
             'public_key': public_key}
 
 
 def _deserialize_party_description(user_input: JSON) -> PartyDescription:
     """Deserialize a PartyDescription object from JSON."""
-    name = user_input['name']
+    id_ = user_input['id']
     public_key = load_pem_public_key(
             user_input['public_key'].encode('ascii'), default_backend())
-    return PartyDescription(name, public_key)
+    return PartyDescription(id_, public_key)
 
 
 def _serialize_site_description(site_desc: SiteDescription) -> JSON:
     """Serialize a SiteDescription object to JSON."""
     result = dict()     # type: JSON
-    result['name'] = site_desc.name
-    result['owner_name'] = site_desc.owner_name
-    result['admin_name'] = site_desc.admin_name
+    result['id'] = site_desc.id
+    result['owner_id'] = site_desc.owner_id
+    result['admin_id'] = site_desc.admin_id
     result['endpoint'] = site_desc.endpoint
     result['store'] = site_desc.store
     result['runner'] = site_desc.runner
@@ -77,9 +77,9 @@ def _serialize_site_description(site_desc: SiteDescription) -> JSON:
 def _deserialize_site_description(user_input: JSON) -> SiteDescription:
     """Deserialize a SiteDescription object from JSON."""
     return SiteDescription(
-            user_input['name'],
-            user_input['owner_name'],
-            user_input['admin_name'],
+            user_input['id'],
+            user_input['owner_id'],
+            user_input['admin_id'],
             user_input['endpoint'],
             user_input['runner'],
             user_input['store'],

--- a/tests/test_rule_signatures.py
+++ b/tests/test_rule_signatures.py
@@ -4,63 +4,61 @@ from proof_of_concept.policy.rules import (
 
 def test_in_asset_collection_signatures(private_key):
     rule = InAssetCollection(
-            'id:party1:dataset.asset1', 'id:party1:collection:collection1')
+            'asset:party1:dataset.asset1:party1:site1',
+            'asset_collection:party1:collection.collection1')
     assert not rule.has_valid_signature(private_key.public_key())
     rule.sign(private_key)
     assert rule.has_valid_signature(private_key.public_key())
-    rule.asset = 'id:party1:dataset.asset2'
+    rule.asset = 'asset:party1:dataset.asset2:party1:site1'
     assert not rule.has_valid_signature(private_key.public_key())
-    rule.asset = 'id:party1:dataset.asset1'
+    rule.asset = 'asset:party1:dataset.asset1:party1:site1'
     assert rule.has_valid_signature(private_key.public_key())
-    rule.collection = 'id:party2:collection.collection1'
+    rule.collection = 'asset_collection:party2:collection.collection1'
     assert not rule.has_valid_signature(private_key.public_key())
 
 
 def test_in_party_collection_signatures(private_key):
     rule = InPartyCollection(
-            'party1', 'id:party1:collection.parties')
+            'party:ns1:party1',
+            'party_collection:ns1:collection.parties')
     assert not rule.has_valid_signature(private_key.public_key())
     rule.sign(private_key)
     assert rule.has_valid_signature(private_key.public_key())
-    rule.party = 'party2'
+    rule.party = 'party:ns2:party2'
     assert not rule.has_valid_signature(private_key.public_key())
-    rule.party = 'party1'
+    rule.party = 'party:ns1:party1'
     assert rule.has_valid_signature(private_key.public_key())
-    rule.collection = 'id:party2:collection.parties'
+    rule.collection = 'party_collection:ns2:collection.parties'
     assert not rule.has_valid_signature(private_key.public_key())
 
 
 def test_may_access_signatures(private_key):
-    rule = MayAccess('id:site1', 'id:party2:dataset.asset1')
+    rule = MayAccess('site:ns1:site1', 'asset:ns2:dataset.asset1:ns2:site2')
     assert not rule.has_valid_signature(private_key.public_key())
     rule.sign(private_key)
     assert rule.has_valid_signature(private_key.public_key())
-    rule.site = 'id:site'
+    rule.site = 'site:ns1:site'
     assert not rule.has_valid_signature(private_key.public_key())
-    rule.site = 'id:site1'
+    rule.site = 'site:ns1:site1'
     assert rule.has_valid_signature(private_key.public_key())
-    rule.asset = 'id:party1:dataset.asset2'
+    rule.asset = 'asset:ns1:dataset.asset2:ns1:site1'
     assert not rule.has_valid_signature(private_key.public_key())
 
 
 def test_result_of_in_signatures(private_key):
     rule = ResultOfDataIn(
-            'id:party1:dataset.asset1', 'id:party1:software.asset2',
-            'id:party2:collection.collection1')
+            'asset:ns1:dataset.asset1:ns1:site1',
+            'asset:ns1:software.asset2:ns1:site1',
+            'asset_collection:ns2:collection.collection1')
 
     assert not rule.has_valid_signature(private_key.public_key())
     rule.sign(private_key)
     assert rule.has_valid_signature(private_key.public_key())
 
-    rule.data_asset = 'id:party2:dataset.test'
+    rule.data_asset = 'asset:ns2:dataset.test:ns2:site2'
     assert not rule.has_valid_signature(private_key.public_key())
-    rule.data_asset = 'id:party1:dataset.asset1'
+    rule.data_asset = 'asset:ns1:dataset.asset1:ns1:site1'
     assert rule.has_valid_signature(private_key.public_key())
 
-    rule.compute_asset = 'party1:software.asset2'
-    assert not rule.has_valid_signature(private_key.public_key())
-    rule.compute_asset = 'id:party1:software.asset2'
-    assert rule.has_valid_signature(private_key.public_key())
-
-    rule.collection = 'id:party2:collection.coll'
+    rule.collection = 'asset_collection:ns2:collection.coll'
     assert not rule.has_valid_signature(private_key.public_key())

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -32,100 +32,126 @@ def test_pii(registry_server):
 
     scenario['rules-party1'] = [
             InAssetCollection(
-                'id:party1_ns:dataset.pii1:site1',
-                'id:party1_ns:collection.PII1'),
-            MayAccess('site1', 'id:party1_ns:collection.PII1'),
+                'asset:party1_ns:dataset.pii1:party1_ns:site1',
+                'asset_collection:party1_ns:collection.PII1'),
+            MayAccess(
+                'site:party1_ns:site1',
+                'asset_collection:party1_ns:collection.PII1'),
             ResultOfDataIn(
-                'id:party1_ns:collection.PII1', '*',
-                'id:party1_ns:collection.PII1'),
+                'asset_collection:party1_ns:collection.PII1', '*',
+                'asset_collection:party1_ns:collection.PII1'),
             ResultOfDataIn(
-                'id:party1_ns:collection.PII1',
-                'id:ddm_ns:software.anonymise:site3',
-                'id:party1_ns:collection.ScienceOnly1'),
+                'asset_collection:party1_ns:collection.PII1',
+                'asset:ddm_ns:software.anonymise:ddm_ns:site3',
+                'asset_collection:party1_ns:collection.ScienceOnly1'),
             ResultOfDataIn(
-                'id:party1_ns:collection.PII1',
-                'id:ddm_ns:software.aggregate:site3',
-                'id:ddm_ns:collection.Public'),
+                'asset_collection:party1_ns:collection.PII1',
+                'asset:ddm_ns:software.aggregate:ddm_ns:site3',
+                'asset_collection:ddm_ns:collection.Public'),
             ResultOfDataIn(
-                'id:party1_ns:collection.ScienceOnly1', '*',
-                'id:party1_ns:collection.ScienceOnly1'),
+                'asset_collection:party1_ns:collection.ScienceOnly1', '*',
+                'asset_collection:party1_ns:collection.ScienceOnly1'),
             InAssetCollection(
-                'id:party1_ns:collection.ScienceOnly1',
-                'id:ddm_ns:collection.ScienceOnly'),
+                'asset_collection:party1_ns:collection.ScienceOnly1',
+                'asset_collection:ddm_ns:collection.ScienceOnly'),
             ]
 
     scenario['rules-party2'] = [
             InAssetCollection(
-                'id:party2_ns:dataset.pii2:site2',
-                'id:party2_ns:collection.PII2'),
-            MayAccess('site2', 'id:party2_ns:collection.PII2'),
-            MayAccess('site1', 'id:party2_ns:collection.PII2'),
+                'asset:party2_ns:dataset.pii2:party2_ns:site2',
+                'asset_collection:party2_ns:collection.PII2'),
+            MayAccess(
+                'site:party2_ns:site2',
+                'asset_collection:party2_ns:collection.PII2'),
+            MayAccess(
+                'site:party1_ns:site1',
+                'asset_collection:party2_ns:collection.PII2'),
             ResultOfDataIn(
-                'id:party2_ns:collection.PII2', '*',
-                'id:party2_ns:collection.PII2'),
+                'asset_collection:party2_ns:collection.PII2', '*',
+                'asset_collection:party2_ns:collection.PII2'),
             ResultOfDataIn(
-                'id:party2_ns:collection.PII2',
-                'id:ddm_ns:software.anonymise:site3',
-                'id:party2_ns:collection.ScienceOnly2'),
+                'asset_collection:party2_ns:collection.PII2',
+                'asset:ddm_ns:software.anonymise:ddm_ns:site3',
+                'asset_collection:party2_ns:collection.ScienceOnly2'),
             ResultOfDataIn(
-                'id:party2_ns:collection.ScienceOnly2', '*',
-                'id:party2_ns:collection.ScienceOnly2'),
+                'asset_collection:party2_ns:collection.ScienceOnly2', '*',
+                'asset_collection:party2_ns:collection.ScienceOnly2'),
             InAssetCollection(
-                'id:party2_ns:collection.ScienceOnly2',
-                'id:ddm_ns:collection.ScienceOnly'),
+                'asset_collection:party2_ns:collection.ScienceOnly2',
+                'asset_collection:ddm_ns:collection.ScienceOnly'),
             ]
 
     scenario['rules-ddm'] = [
             InAssetCollection(
-                'id:ddm_ns:software.anonymise:site3',
-                'id:ddm_ns:collection.PublicSoftware'),
+                'asset:ddm_ns:software.anonymise:ddm_ns:site3',
+                'asset_collection:ddm_ns:collection.PublicSoftware'),
             InAssetCollection(
-                'id:ddm_ns:software.aggregate:site3',
-                'id:ddm_ns:collection.PublicSoftware'),
+                'asset:ddm_ns:software.aggregate:ddm_ns:site3',
+                'asset_collection:ddm_ns:collection.PublicSoftware'),
             InAssetCollection(
-                'id:ddm_ns:software.combine:site3',
-                'id:ddm_ns:collection.PublicSoftware'),
-            MayAccess('*', 'id:ddm_ns:collection.PublicSoftware'),
+                'asset:ddm_ns:software.combine:ddm_ns:site3',
+                'asset_collection:ddm_ns:collection.PublicSoftware'),
+            MayAccess(
+                '*', 'asset_collection:ddm_ns:collection.PublicSoftware'),
             ResultOfDataIn(
-                'id:ddm_ns:collection.Public', '*',
-                'id:ddm_ns:collection.Public'),
+                'asset_collection:ddm_ns:collection.Public', '*',
+                'asset_collection:ddm_ns:collection.Public'),
 
             ResultOfComputeIn(
-                '*', 'id:ddm_ns:software.anonymise:site3',
-                'id:ddm_ns:collection.Public'),
+                '*', 'asset:ddm_ns:software.anonymise:ddm_ns:site3',
+                'asset_collection:ddm_ns:collection.Public'),
 
             ResultOfComputeIn(
-                '*', 'id:ddm_ns:software.aggregate:site3',
-                'id:ddm_ns:collection.Public'),
+                '*', 'asset:ddm_ns:software.aggregate:ddm_ns:site3',
+                'asset_collection:ddm_ns:collection.Public'),
 
             ResultOfComputeIn(
-                '*', 'id:ddm_ns:software.combine:site3',
-                'id:ddm_ns:collection.Public'),
+                '*', 'asset:ddm_ns:software.combine:ddm_ns:site3',
+                'asset_collection:ddm_ns:collection.Public'),
 
-            MayAccess('site3', 'id:ddm_ns:collection.ScienceOnly'),
-            MayAccess('site1', 'id:ddm_ns:collection.Public'),
-            MayAccess('site2', 'id:ddm_ns:collection.Public'),
-            MayAccess('site3', 'id:ddm_ns:collection.Public'),
+            MayAccess(
+                'site:ddm_ns:site3',
+                'asset_collection:ddm_ns:collection.ScienceOnly'),
+            MayAccess(
+                'site:party1_ns:site1',
+                'asset_collection:ddm_ns:collection.Public'),
+            MayAccess(
+                'site:party2_ns:site2',
+                'asset_collection:ddm_ns:collection.Public'),
+            MayAccess(
+                'site:ddm_ns:site3',
+                'asset_collection:ddm_ns:collection.Public'),
             ]
 
     scenario['sites'] = [
-            Site(name='site1', owner='party1', namespace='party1_ns',
-                 stored_data=[
-                     DataAsset('id:party1_ns:dataset.pii1:site1', 42)],
-                 rules=scenario['rules-party1']),
-            Site(name='site2', owner='party2', namespace='party2_ns',
-                 stored_data=[
-                     DataAsset('id:party2_ns:dataset.pii2:site2', 3)],
-                 rules=scenario['rules-party2']),
-            Site(name='site3', owner='ddm', namespace='ddm_ns',
-                 stored_data=[
-                     ComputeAsset(
-                         'id:ddm_ns:software.combine:site3', None, None),
-                     ComputeAsset(
-                         'id:ddm_ns:software.anonymise:site3', None, None),
-                     ComputeAsset(
-                         'id:ddm_ns:software.aggregate:site3', None, None)],
-                 rules=scenario['rules-ddm'])]
+            Site(
+                name='site:party1_ns:site1', owner='party:party1_ns:party1',
+                namespace='party1_ns',
+                stored_data=[
+                    DataAsset(
+                        'asset:party1_ns:dataset.pii1:party1_ns:site1', 42)],
+                rules=scenario['rules-party1']),
+            Site(
+                name='site:party2_ns:site2', owner='party:party2_ns:party2',
+                namespace='party2_ns',
+                stored_data=[
+                    DataAsset(
+                        'asset:party2_ns:dataset.pii2:party2_ns:site2', 3)],
+                rules=scenario['rules-party2']),
+            Site(
+                name='site:ddm_ns:site3', owner='party:ddm_ns:ddm',
+                namespace='ddm_ns',
+                stored_data=[
+                    ComputeAsset(
+                        'asset:ddm_ns:software.combine:ddm_ns:site3',
+                        None, None),
+                    ComputeAsset(
+                        'asset:ddm_ns:software.anonymise:ddm_ns:site3',
+                        None, None),
+                    ComputeAsset(
+                        'asset:ddm_ns:software.aggregate:ddm_ns:site3',
+                        None, None)],
+                rules=scenario['rules-ddm'])]
 
     workflow = Workflow(
             ['x1', 'x2'], {'result': 'aggregate.y'}, [
@@ -133,23 +159,26 @@ def test_pii(registry_server):
                     name='combine',
                     inputs={'x1': 'x1', 'x2': 'x2'},
                     outputs=['y'],
-                    compute_asset_id='id:ddm_ns:software.combine:site3'),
+                    compute_asset_id=(
+                        'asset:ddm_ns:software.combine:ddm_ns:site3')),
                 WorkflowStep(
                     name='anonymise',
                     inputs={'x1': 'combine.y'},
                     outputs=['y'],
-                    compute_asset_id='id:ddm_ns:software.anonymise:site3'),
+                    compute_asset_id=(
+                        'asset:ddm_ns:software.anonymise:ddm_ns:site3')),
                 WorkflowStep(
                     name='aggregate',
                     inputs={'x1': 'anonymise.y'},
                     outputs=['y'],
-                    compute_asset_id='id:ddm_ns:software.aggregate:site3')
+                    compute_asset_id=(
+                        'asset:ddm_ns:software.aggregate:ddm_ns:site3'))
             ]
     )
 
     inputs = {
-            'x1': 'id:party1_ns:dataset.pii1:site1',
-            'x2': 'id:party2_ns:dataset.pii2:site2'}
+            'x1': 'asset:party1_ns:dataset.pii1:party1_ns:site1',
+            'x2': 'asset:party2_ns:dataset.pii2:party2_ns:site2'}
 
     scenario['job'] = Job(workflow, inputs)
     scenario['user_site'] = scenario['sites'][1]
@@ -162,46 +191,67 @@ def test_saas_with_data(registry_server):
     scenario = dict()     # type: Dict[str, Any]
 
     scenario['rules-party1'] = [
-            MayAccess('site1', 'id:party1_ns:dataset.data1:site1'),
-            MayAccess('site2', 'id:party1_ns:dataset.data1:site1'),
+            MayAccess(
+                'site:party1_ns:site1',
+                'asset:party1_ns:dataset.data1:party1_ns:site1'),
+            MayAccess(
+                'site:party2_ns:site2',
+                'asset:party1_ns:dataset.data1:party1_ns:site1'),
             ResultOfDataIn(
-                'id:party1_ns:dataset.data1:site1',
-                'id:party2_ns:software.addition:site2',
-                'id:party1_ns:collection.result1'),
-            MayAccess('site1', 'id:party1_ns:collection.result1'),
-            MayAccess('site2', 'id:party1_ns:collection.result1'),
+                'asset:party1_ns:dataset.data1:party1_ns:site1',
+                'asset:party2_ns:software.addition:party2_ns:site2',
+                'asset_collection:party1_ns:collection.result1'),
+            MayAccess(
+                'site:party1_ns:site1',
+                'asset_collection:party1_ns:collection.result1'),
+            MayAccess(
+                'site:party2_ns:site2',
+                'asset_collection:party1_ns:collection.result1'),
             ]
 
     scenario['rules-party2'] = [
-            MayAccess('site2', 'id:party2_ns:dataset.data2:site2'),
-            MayAccess('site2', 'id:party2_ns:software.addition:site2'),
+            MayAccess(
+                'site:party2_ns:site2',
+                'asset:party2_ns:dataset.data2:party2_ns:site2'),
+            MayAccess(
+                'site:party2_ns:site2',
+                'asset:party2_ns:software.addition:party2_ns:site2'),
             ResultOfDataIn(
-                'id:party2_ns:dataset.data2:site2',
-                'id:party2_ns:software.addition:site2',
-                'id:party2_ns:collection.result2'),
+                'asset:party2_ns:dataset.data2:party2_ns:site2',
+                'asset:party2_ns:software.addition:party2_ns:site2',
+                'asset_collection:party2_ns:collection.result2'),
             ResultOfComputeIn(
-                'id:party2_ns:dataset.data2:site2',
-                'id:party2_ns:software.addition:site2',
-                'id:party2_ns:collection.result2'),
+                'asset:party2_ns:dataset.data2:party2_ns:site2',
+                'asset:party2_ns:software.addition:party2_ns:site2',
+                'asset_collection:party2_ns:collection.result2'),
             ResultOfComputeIn(
-                'id:party1_ns:dataset.data1:site1',
-                'id:party2_ns:software.addition:site2',
-                'id:party2_ns:collection.result2'),
-            MayAccess('site1', 'id:party2_ns:collection.result2'),
-            MayAccess('site2', 'id:party2_ns:collection.result2'),
-            MayAccess('site2', 'id:party2_ns:software.addition:site2'),
+                'asset:party1_ns:dataset.data1:party1_ns:site1',
+                'asset:party2_ns:software.addition:party2_ns:site2',
+                'asset_collection:party2_ns:collection.result2'),
+            MayAccess(
+                'site:party1_ns:site1',
+                'asset_collection:party2_ns:collection.result2'),
+            MayAccess(
+                'site:party2_ns:site2',
+                'asset_collection:party2_ns:collection.result2'),
+            MayAccess(
+                'site:party2_ns:site2',
+                'asset:party2_ns:software.addition:party2_ns:site2'),
             ]
 
     scenario['sites'] = [
             Site(
-                'site1', 'party1', 'party1_ns',
-                [DataAsset('id:party1_ns:dataset.data1:site1', 42)],
+                'site:party1_ns:site1', 'party:party1_ns:party1', 'party1_ns',
+                [DataAsset(
+                    'asset:party1_ns:dataset.data1:party1_ns:site1', 42)],
                 scenario['rules-party1']),
             Site(
-                'site2', 'party2', 'party2_ns',
-                [DataAsset('id:party2_ns:dataset.data2:site2', 3),
+                'site:party2_ns:site2', 'party:party2_ns:party2', 'party2_ns',
+                [DataAsset(
+                    'asset:party2_ns:dataset.data2:party2_ns:site2', 3),
                  ComputeAsset(
-                     'id:party2_ns:software.addition:site2', None, None)],
+                     'asset:party2_ns:software.addition:party2_ns:site2',
+                     None, None)],
                 scenario['rules-party2'])]
 
     workflow = Workflow(inputs=['x1', 'x2'],
@@ -211,12 +261,13 @@ def test_saas_with_data(registry_server):
                     name='addstep',
                     inputs={'x1': 'x1', 'x2': 'x2'},
                     outputs=['y'],
-                    compute_asset_id='id:party2_ns:software.addition:site2')
+                    compute_asset_id=(
+                        'asset:party2_ns:software.addition:party2_ns:site2'))
                 ])
 
     inputs = {
-            'x1': 'id:party1_ns:dataset.data1:site1',
-            'x2': 'id:party2_ns:dataset.data2:site2'}
+            'x1': 'asset:party1_ns:dataset.data1:party1_ns:site1',
+            'x2': 'asset:party2_ns:dataset.data2:party2_ns:site2'}
 
     scenario['job'] = Job(workflow, inputs)
     scenario['user_site'] = scenario['sites'][0]

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -125,21 +125,21 @@ def test_pii(registry_server):
 
     scenario['sites'] = [
             Site(
-                name='site:party1_ns:site1', owner='party:party1_ns:party1',
+                name='site1', owner='party:party1_ns:party1',
                 namespace='party1_ns',
                 stored_data=[
                     DataAsset(
                         'asset:party1_ns:dataset.pii1:party1_ns:site1', 42)],
                 rules=scenario['rules-party1']),
             Site(
-                name='site:party2_ns:site2', owner='party:party2_ns:party2',
+                name='site2', owner='party:party2_ns:party2',
                 namespace='party2_ns',
                 stored_data=[
                     DataAsset(
                         'asset:party2_ns:dataset.pii2:party2_ns:site2', 3)],
                 rules=scenario['rules-party2']),
             Site(
-                name='site:ddm_ns:site3', owner='party:ddm_ns:ddm',
+                name='site3', owner='party:ddm_ns:ddm',
                 namespace='ddm_ns',
                 stored_data=[
                     ComputeAsset(
@@ -241,12 +241,12 @@ def test_saas_with_data(registry_server):
 
     scenario['sites'] = [
             Site(
-                'site:party1_ns:site1', 'party:party1_ns:party1', 'party1_ns',
+                'site1', 'party:party1_ns:party1', 'party1_ns',
                 [DataAsset(
                     'asset:party1_ns:dataset.data1:party1_ns:site1', 42)],
                 scenario['rules-party1']),
             Site(
-                'site:party2_ns:site2', 'party:party2_ns:party2', 'party2_ns',
+                'site2', 'party:party2_ns:party2', 'party2_ns',
                 [DataAsset(
                     'asset:party2_ns:dataset.data2:party2_ns:site2', 3),
                  ComputeAsset(


### PR DESCRIPTION
This implements task 1245. It adds some definitions to the documentation, and then changes the code to match. The `AssetId` class has been renamed to `Identifier` and extended to cover identities of other kinds of objects. Most of this is just dumb renaming, so don't spend too much time on it. b1b28ce is the more interesting commit.