### PR TITLE
Add registry docker image build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include LICENSE
 include README.rst
+include proof_of_concept/rest/site_api.yaml
+include proof_of_concept/rest/registry_api.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: docker
-docker: registry_docker
+.PHONY: docker_images
+docker_images: registry_docker_image
 
 .PHONY: docker_clean
 docker_clean:
-	docker rmi mahiru-registry:latest
+	docker rmi -f mahiru-registry:latest
 
-.PHONY: registry_docker
-registry_docker:
+.PHONY: registry_docker_image
+registry_docker_image:
 	docker build . -f docker/registry.Dockerfile -t mahiru-registry:latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: docker
+docker: registry_docker
+
+.PHONY: docker_clean
+docker_clean:
+	docker rmi mahiru-registry:latest
+
+.PHONY: registry_docker
+registry_docker:
+	docker build . -f docker/registry.Dockerfile -t mahiru-registry:latest

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -8,6 +8,8 @@ function stop_container {
     kill -TERM $(cat ${pid_file})
 }
 
+# Docker sends us a SIGTERM on 'docker stop'.
+# This catches it and shuts down cleanly by calling the function above
 trap stop_container SIGTERM
 
 echo 'Installed handler' 1>&2

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+pid_file='/var/run/gunicorn/gunicorn.pid'
+
+function stop_container {
+    service nginx stop
+    gunicorn_pid=$(cat ${pid_file})
+    kill -TERM $(cat ${pid_file})
+}
+
+trap stop_container SIGTERM
+
+echo 'Installed handler' 1>&2
+
+service nginx start
+
+su -c ". /home/mahiru/.env/bin/activate && gunicorn --pid ${pid_file} --access-logfile /var/log/gunicorn/access.log --error-logfile /var/log/gunicorn/error.log --capture-output --bind 127.0.0.1:8000 'proof_of_concept.rest.registry:wsgi_app()'" mahiru &
+
+wait
+
+rm -f ${pid_file}

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -14,7 +14,7 @@ echo 'Installed handler' 1>&2
 
 service nginx start
 
-su -c ". /home/mahiru/.env/bin/activate && gunicorn --pid ${pid_file} --access-logfile /var/log/gunicorn/access.log --error-logfile /var/log/gunicorn/error.log --capture-output --bind 127.0.0.1:8000 'proof_of_concept.rest.registry:wsgi_app()'" mahiru &
+su -c "/home/mahiru/.local/bin/gunicorn --pid ${pid_file} --access-logfile /var/log/gunicorn/access.log --error-logfile /var/log/gunicorn/error.log --capture-output --bind 127.0.0.1:8000 'proof_of_concept.rest.registry:wsgi_app()'" mahiru &
 
 wait
 

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+wsgi_entry_point="$1"
 pid_file='/var/run/gunicorn/gunicorn.pid'
 
 function stop_container {
@@ -16,7 +17,7 @@ echo 'Installed handler' 1>&2
 
 service nginx start
 
-su -c "/home/mahiru/.local/bin/gunicorn --pid ${pid_file} --access-logfile /var/log/gunicorn/access.log --error-logfile /var/log/gunicorn/error.log --capture-output --bind 127.0.0.1:8000 'proof_of_concept.rest.registry:wsgi_app()'" mahiru &
+su -c "/home/mahiru/.local/bin/gunicorn --pid ${pid_file} --access-logfile /var/log/gunicorn/access.log --error-logfile /var/log/gunicorn/error.log --capture-output --bind 127.0.0.1:8000 '${wsgi_entry_point}'" mahiru &
 
 wait
 

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -17,7 +17,7 @@ echo 'Installed handler' 1>&2
 
 service nginx start
 
-su -c "/home/mahiru/.local/bin/gunicorn --pid ${pid_file} --access-logfile /var/log/gunicorn/access.log --error-logfile /var/log/gunicorn/error.log --capture-output --bind 127.0.0.1:8000 '${wsgi_entry_point}'" mahiru &
+su -c "gunicorn --pid ${pid_file} --access-logfile /var/log/gunicorn/access.log --error-logfile /var/log/gunicorn/error.log --capture-output --bind 127.0.0.1:8000 '${wsgi_entry_point}'" mahiru &
 
 wait
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,7 @@
+server {
+    listen 80 default_server;
+    server_name _;
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+    }
+}

--- a/docker/registry.Dockerfile
+++ b/docker/registry.Dockerfile
@@ -20,8 +20,7 @@ RUN chmod +x /usr/local/bin/init.sh
 
 COPY . /home/mahiru/
 RUN chown -R mahiru:mahiru /home/mahiru
-USER mahiru
-RUN pip3 install gunicorn /home/mahiru
+RUN pip3 install --system gunicorn /home/mahiru
 
 USER root
 CMD ["/usr/local/bin/init.sh", "proof_of_concept.rest.registry:wsgi_app()"]

--- a/docker/registry.Dockerfile
+++ b/docker/registry.Dockerfile
@@ -24,4 +24,4 @@ USER mahiru
 RUN pip3 install gunicorn /home/mahiru
 
 USER root
-CMD ["/usr/local/bin/init.sh"]
+CMD ["/usr/local/bin/init.sh", "proof_of_concept.rest.registry:wsgi_app()"]

--- a/docker/registry.Dockerfile
+++ b/docker/registry.Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:20.04
+RUN \
+    apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install nginx && \
+    apt-get -y install python3 python3-pip python3-venv python3-wheel
+RUN \
+    useradd mahiru && \
+    mkdir /home/mahiru && \
+    chown -R mahiru:mahiru /home/mahiru
+RUN \
+    mkdir /var/log/gunicorn && \
+    chown mahiru:mahiru /var/log/gunicorn && \
+    mkdir /var/run/gunicorn && \
+    chown mahiru:mahiru /var/run/gunicorn
+
+COPY docker/nginx.conf /etc/nginx/sites-available/default
+COPY docker/init.sh /usr/local/bin/init.sh
+RUN chmod +x /usr/local/bin/init.sh
+
+COPY . /home/mahiru/
+RUN chown -R mahiru:mahiru /home/mahiru
+USER mahiru
+RUN \
+    python3 -m venv /home/mahiru/.env && \
+    . /home/mahiru/.env/bin/activate && \
+    pip3 install wheel && \
+    pip3 install gunicorn /home/mahiru
+
+USER root
+CMD ["/usr/local/bin/init.sh"]

--- a/docker/registry.Dockerfile
+++ b/docker/registry.Dockerfile
@@ -21,11 +21,7 @@ RUN chmod +x /usr/local/bin/init.sh
 COPY . /home/mahiru/
 RUN chown -R mahiru:mahiru /home/mahiru
 USER mahiru
-RUN \
-    python3 -m venv /home/mahiru/.env && \
-    . /home/mahiru/.env/bin/activate && \
-    pip3 install wheel && \
-    pip3 install gunicorn /home/mahiru
+RUN pip3 install gunicorn /home/mahiru
 
 USER root
 CMD ["/usr/local/bin/init.sh"]

--- a/proof_of_concept/rest/registry.py
+++ b/proof_of_concept/rest/registry.py
@@ -197,3 +197,8 @@ class RegistryServer:
         self._server.shutdown()
         self._server.server_close()
         self._thread.join()
+
+
+def wsgi_app() -> App:
+    """Creates a WSGI app for a WSGI runner."""
+    return RegistryRestApi(Registry()).app

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -22,9 +22,7 @@ setup(
     author="Lourens Veen",
     author_email='l.veen@esciencecenter.nl',
     url='https://github.com/SecConNet/proof_of_concept',
-    packages=[
-        'proof_of_concept',
-    ],
+    packages=find_packages(include=['proof_of_concept', 'proof_of_concept.*']),
     include_package_data=True,
     license="Apache Software License 2.0",
     zip_safe=False,
@@ -43,7 +41,8 @@ setup(
     install_requires=[
         'cryptography',
         'python-dateutil',
-        'falcon',
+        'requests',
+        'falcon==3.0.0a3',
         'openapi-schema-validator',
         'ruamel.yaml'
     ],


### PR DESCRIPTION
This adds a Makefile and some scripts which can be used to create a Docker image which runs the registry component as a REST service. Merge #51 as well, because this doesn't work without that.