### PR TITLE
Add docker image for a site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,20 @@
 .PHONY: docker_images
-docker_images: registry_docker_image
+docker_images: base_docker_image registry_docker_image site_docker_image
 
 .PHONY: docker_clean
 docker_clean:
+	docker rmi -f mahiru-site:latest
 	docker rmi -f mahiru-registry:latest
+	docker rmi -f mahiru-base:latest
+
+.PHONY: base_docker_image
+base_docker_image:
+	docker build . -f docker/base.Dockerfile -t mahiru-base:latest
 
 .PHONY: registry_docker_image
-registry_docker_image:
+registry_docker_image: base_docker_image
 	docker build . -f docker/registry.Dockerfile -t mahiru-registry:latest
+
+.PHONY: site_docker_image
+site_docker_image: base_docker_image
+	docker build . -f docker/site.Dockerfile -t mahiru-site:latest

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:20.04
+RUN \
+    apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install nginx && \
+    apt-get -y install python3 python3-pip python3-venv python3-wheel
+RUN \
+    useradd mahiru && \
+    mkdir /home/mahiru && \
+    chown -R mahiru:mahiru /home/mahiru
+RUN \
+    mkdir /var/log/gunicorn && \
+    chown mahiru:mahiru /var/log/gunicorn && \
+    mkdir /var/run/gunicorn && \
+    chown mahiru:mahiru /var/run/gunicorn
+
+COPY docker/nginx.conf /etc/nginx/sites-available/default
+COPY docker/init.sh /usr/local/bin/init.sh
+RUN chmod +x /usr/local/bin/init.sh
+
+COPY . /home/mahiru/
+RUN chown -R mahiru:mahiru /home/mahiru
+RUN pip3 install --system gunicorn /home/mahiru

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.3"
+services:
+  registry:
+    image: mahiru-registry:latest
+    ports:
+      - "80:80"
+  site:
+    image: mahiru-site:latest
+    depends_on:
+      - registry
+    links:
+      - registry

--- a/docker/registry.Dockerfile
+++ b/docker/registry.Dockerfile
@@ -1,26 +1,2 @@
-FROM ubuntu:20.04
-RUN \
-    apt-get update && \
-    apt-get -y upgrade && \
-    apt-get -y install nginx && \
-    apt-get -y install python3 python3-pip python3-venv python3-wheel
-RUN \
-    useradd mahiru && \
-    mkdir /home/mahiru && \
-    chown -R mahiru:mahiru /home/mahiru
-RUN \
-    mkdir /var/log/gunicorn && \
-    chown mahiru:mahiru /var/log/gunicorn && \
-    mkdir /var/run/gunicorn && \
-    chown mahiru:mahiru /var/run/gunicorn
-
-COPY docker/nginx.conf /etc/nginx/sites-available/default
-COPY docker/init.sh /usr/local/bin/init.sh
-RUN chmod +x /usr/local/bin/init.sh
-
-COPY . /home/mahiru/
-RUN chown -R mahiru:mahiru /home/mahiru
-RUN pip3 install --system gunicorn /home/mahiru
-
-USER root
+FROM mahiru-base:latest
 CMD ["/usr/local/bin/init.sh", "proof_of_concept.rest.registry:wsgi_app()"]

--- a/docker/site.Dockerfile
+++ b/docker/site.Dockerfile
@@ -1,0 +1,5 @@
+FROM mahiru-base:latest
+
+COPY docker/site.conf /etc/mahiru/mahiru.conf
+
+CMD ["/usr/local/bin/init.sh", "proof_of_concept.rest.ddm_site:wsgi_app()"]

--- a/docker/site.conf
+++ b/docker/site.conf
@@ -1,0 +1,4 @@
+name: site
+namespace: party.example.com
+owner: party:party.example.com:party
+endpoint: http://registry:80

--- a/docker/site.conf
+++ b/docker/site.conf
@@ -1,4 +1,4 @@
 name: site
 namespace: party.example.com
 owner: party:party.example.com:party
-endpoint: http://registry:80
+registry_endpoint: http://registry:80

--- a/proof_of_concept/rest/ddm_site.py
+++ b/proof_of_concept/rest/ddm_site.py
@@ -227,4 +227,4 @@ def wsgi_app() -> App:
     site = Site(
             settings.name, settings.owner, settings.namespace, [], [],
             registry_client)
-    return SiteRestApi(site.policy_store, site.store, site.runner)
+    return SiteRestApi(site.policy_store, site.store, site.runner).app

--- a/proof_of_concept/rest/ddm_site.py
+++ b/proof_of_concept/rest/ddm_site.py
@@ -196,11 +196,12 @@ class Settings:
         name: Name of the site.
         namespace: Namespace controlled by the site's policy server.
         owner: Party owning the site.
-        endpoint: Registry endpoint location.
+        registry_endpoint: Registry endpoint location.
     """
     def __init__(
             self,
-            name: str, namespace: str, owner: Identifier, endpoint: str
+            name: str, namespace: str, owner: Identifier,
+            registry_endpoint: str
             ) -> None:
         """Create a Settings object.
 
@@ -208,12 +209,12 @@ class Settings:
             name: Name of the site.
             namespace: Namespace controlled by the site's policy server.
             owner: Party owning the site.
-            endpoint: Registry endpoint location.
+            registry_endpoint: Registry endpoint location.
         """
         self.name = name
         self.namespace = namespace
         self.owner = owner
-        self.endpoint = endpoint
+        self.registry_endpoint = registry_endpoint
 
 
 load_settings = yatiml.load_function(Settings, Identifier)
@@ -226,7 +227,7 @@ def wsgi_app() -> App:
     """Creates a WSGI app for a WSGI runner."""
     settings = load_settings(default_config_location)
 
-    registry_client = RegistryClient(settings.endpoint)
+    registry_client = RegistryClient(settings.registry_endpoint)
     site = Site(
             settings.name, settings.owner, settings.namespace, [], [],
             registry_client)

--- a/proof_of_concept/rest/ddm_site.py
+++ b/proof_of_concept/rest/ddm_site.py
@@ -219,9 +219,12 @@ class Settings:
 load_settings = yatiml.load_function(Settings, Identifier)
 
 
+default_config_location = Path('/etc/mahiru/mahiru.conf')
+
+
 def wsgi_app() -> App:
     """Creates a WSGI app for a WSGI runner."""
-    settings = load_settings(Path('/etc/mahiru/mahiru.conf'))
+    settings = load_settings(default_config_location)
 
     registry_client = RegistryClient(settings.endpoint)
     site = Site(

--- a/proof_of_concept/rest/replication.py
+++ b/proof_of_concept/rest/replication.py
@@ -81,6 +81,7 @@ class ReplicationRestClient(IReplicationService[T]):
         while datetime.now() < start_time + timedelta(seconds=100):
             try:
                 r = requests.get(self._endpoint, params=params)
+                break
             except requests.ConnectionError:
                 pass
 

--- a/proof_of_concept/rest/replication.py
+++ b/proof_of_concept/rest/replication.py
@@ -5,6 +5,7 @@ import requests
 from typing import Dict, Generic, Optional, Type, TypeVar
 
 from falcon import Request, Response
+from retrying import retry
 
 from proof_of_concept.definitions.interfaces import IReplicationService
 from proof_of_concept.definitions.registry import RegisteredObject
@@ -20,6 +21,11 @@ logger = logging.getLogger(__name__)
 
 
 T = TypeVar('T')
+
+
+def _retry_on_connection_error(exception: BaseException) -> bool:
+    """Helper for retrying connections."""
+    return isinstance(exception, requests.ConnectionError)
 
 
 class ReplicationHandler(Generic[T]):
@@ -76,23 +82,21 @@ class ReplicationRestClient(IReplicationService[T]):
         if from_version is not None:
             params['from_version'] = from_version
 
-        start_time = datetime.now()
-        r = None
-        while datetime.now() < start_time + timedelta(seconds=100):
-            try:
-                r = requests.get(self._endpoint, params=params)
-                break
-            except requests.ConnectionError:
-                pass
-
-        if r is None:
-            raise RuntimeError('Could not connect to registry')
+        r = self._retry_http_get(params)
 
         update_json = r.json()
         logger.info(f'Replication update: {update_json}')
         self._validator.validate(self.UpdateType.__name__, update_json)
         logger.info(f'Validated against {self.UpdateType.__name__}')
         return deserialize(self.UpdateType, update_json)
+
+    @retry(                                             # type: ignore
+            stop_max_delay=20000, wait_fixed=500,
+            retry_on_exception=_retry_on_connection_error)
+    def _retry_http_get(
+            self, params: Dict[str, int]) -> requests.Response:
+        """Do an HTTP get and retry for a while on failure."""
+        return requests.get(self._endpoint, params=params)
 
 
 class PolicyRestClient(ReplicationRestClient[Rule]):

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,9 @@ ignore_missing_imports = True
 [mypy-openapi_schema_validator.*]
 ignore_missing_imports = True
 
+[mypy-retrying.*]
+ignore_missing_imports = True
+
 [mypy-ruamel.*]
 ignore_missing_imports = True
 

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'requests',
         'falcon==3.0.0a3',
         'openapi-schema-validator',
+        'retrying',
         'ruamel.yaml<=0.16.10',
         'yatiml'
     ],


### PR DESCRIPTION
This adds a Docker image for a site (almost completely the same as the registry image, just a different endpoint) and a docker-compose file that starts a registry and a site, and has the site connect to the registry. It also adds auto-reconnect to replication sources, because without that you get in trouble when trying to docker-compose two containers together (and it's a good idea anyway, in a distributed system). I should probably use retrying for that. Maybe tomorrow.

Goes on top of #53, please don't merge as the target is set for reviewing, it's not where this will eventually go.