### PR TITLE
Store images in asset store

### DIFF
--- a/proof_of_concept/components/asset_store.py
+++ b/proof_of_concept/components/asset_store.py
@@ -1,6 +1,10 @@
 """Storage and exchange of data and compute assets."""
+from copy import copy
 import logging
-from typing import Dict
+from pathlib import Path
+from shutil import copyfile, move, rmtree
+from tempfile import mkdtemp
+from typing import Dict, Optional
 
 from proof_of_concept.definitions.assets import Asset
 from proof_of_concept.definitions.identifier import Identifier
@@ -14,17 +18,29 @@ logger = logging.getLogger(__name__)
 
 class AssetStore(IAssetStore):
     """A simple store for assets."""
-    def __init__(self, policy_evaluator: PolicyEvaluator) -> None:
+    def __init__(
+            self, policy_evaluator: PolicyEvaluator,
+            image_dir: Optional[Path] = None) -> None:
         """Create a new empty AssetStore."""
         self._policy_evaluator = policy_evaluator
         self._permission_calculator = PermissionCalculator(policy_evaluator)
         self._assets = dict()  # type: Dict[Identifier, Asset]
+        if image_dir is None:
+            image_dir = Path(mkdtemp())
+        self._image_dir = image_dir
 
-    def store(self, asset: Asset) -> None:
+    def close(self) -> None:
+        """Releases resources, call when done."""
+        rmtree(self._image_dir, ignore_errors=True)
+
+    def store(self, asset: Asset, move_image: bool = False) -> None:
         """Stores an asset.
 
         Args:
             asset: asset object to store
+            move_image: If the asset has an image and True is passed,
+                the image file will be moved rather than copied into
+                the store.
 
         Raises:
             KeyError: If there's already an asset with the asset id.
@@ -33,10 +49,17 @@ class AssetStore(IAssetStore):
         if asset.id in self._assets:
             raise KeyError(f'There is already an asset with id {id}')
 
-        self._assets[asset.id] = asset
+        self._assets[asset.id] = copy(asset)
+        if asset.image_location is not None:
+            src_path = Path(asset.image_location)
+            tgt_path = self._image_dir / f'{asset.id}.tar.gz'
+            if move_image:
+                move(str(src_path), str(tgt_path))
+            else:
+                copyfile(src_path, tgt_path)
+            self._assets[asset.id].image_location = str(tgt_path)
 
-    def retrieve(self, asset_id: Identifier, requester: str
-                 ) -> Asset:
+    def retrieve(self, asset_id: Identifier, requester: str) -> Asset:
         """Retrieves an asset.
 
         Args:

--- a/proof_of_concept/components/ddm_site.py
+++ b/proof_of_concept/components/ddm_site.py
@@ -92,6 +92,10 @@ class Site:
         for asset in stored_data:
             self.store.store(asset)
 
+    def close(self) -> None:
+        """Release resources."""
+        self.store.close()
+
     def __repr__(self) -> str:
         """Return a string representation of this object."""
         return 'Site({})'.format(self.id)

--- a/proof_of_concept/components/step_runner.py
+++ b/proof_of_concept/components/step_runner.py
@@ -97,7 +97,7 @@ class JobRun(Thread):
                         metadata = Metadata(step_subjob, result_item)
                         asset = DataAsset(
                                 Identifier.from_id_hash(result_id_hash),
-                                output_value, metadata)
+                                output_value, None, metadata)
                         self._target_store.store(asset)
 
                     steps_to_do.remove(step)

--- a/proof_of_concept/definitions/assets.py
+++ b/proof_of_concept/definitions/assets.py
@@ -32,12 +32,19 @@ class Asset:
     """Asset, a representation of a computation or piece of data."""
 
     def __init__(self, id: Union[str, Identifier], data: Any,
-                 metadata: Optional[Metadata] = None):
-        """Constructor.
+                 image_location: Optional[str] = None,
+                 metadata: Optional[Metadata] = None
+                 ) -> None:
+        """Create an Asset.
+
+        Assets may have either a data item (a JSON-serialisable Python
+        value) associated with them, or reference Docker image tarball
+        containing data or code.
 
         Args:
             id: Identifier of the asset
             data: Data related to the asset
+            image_location: URL or path to the container image file.
             metadata: Metadata related to the asset. If no metadata is
                 passed, metadata is set to a niljob, indicating that
                 this is an asset that is not the product of some
@@ -50,6 +57,7 @@ class Asset:
             metadata = Metadata(Job.niljob(id), 'dataset')
         self.id = id
         self.data = data
+        self.image_location = image_location
         self.metadata = metadata
 
 

--- a/proof_of_concept/definitions/identifier.py
+++ b/proof_of_concept/definitions/identifier.py
@@ -44,7 +44,7 @@ class Identifier(str):
                 if not cls._segment_regex.match(segment):
                     raise ValueError(f'Invalid identifier segment {segment}')
 
-        return str.__new__(cls, seq)        # type: ignore
+        return str.__new__(cls, seq)
 
     @classmethod
     def from_id_hash(cls, id_hash: str) -> 'Identifier':

--- a/proof_of_concept/rest/serialization.py
+++ b/proof_of_concept/rest/serialization.py
@@ -266,9 +266,10 @@ def _deserialize_asset(user_input: JSON) -> Asset:
     """Deserialize an Asset from JSON."""
     if user_input['data'] is None:
         return ComputeAsset(
-                user_input['id'], user_input['data'], user_input['metadata'])
+                user_input['id'], user_input['data'], None,
+                user_input['metadata'])
     return DataAsset(
-            user_input['id'], user_input['data'], user_input['metadata'])
+            user_input['id'], user_input['data'], None, user_input['metadata'])
 
 
 def _serialize_compute_asset(asset: ComputeAsset) -> JSON:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 This is a PyTest special file, see its documentation.
 """
 import logging
+from pathlib import Path
 from unittest.mock import patch
 from wsgiref.simple_server import WSGIServer
 
@@ -49,3 +50,15 @@ def private_key():
             public_exponent=65537,
             key_size=2048,
             backend=default_backend())
+
+
+@pytest.fixture
+def test_dir():
+    """Returns the directory the tests are in."""
+    return Path(__file__).parent
+
+
+@pytest.fixture
+def temp_path(tmpdir) -> Path:
+    """Returns tmpdir as a standard Path object."""
+    return Path(str(tmpdir))

--- a/tests/test_asset_store.py
+++ b/tests/test_asset_store.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from proof_of_concept.components.asset_store import AssetStore
+from proof_of_concept.definitions.assets import DataAsset
+from proof_of_concept.definitions.identifier import Identifier
+
+
+@pytest.fixture
+def image_dir(temp_path) -> Path:
+    path = temp_path / 'store'
+    path.mkdir(exist_ok=True)
+    return path
+
+
+@pytest.fixture
+def test_image_file(temp_path) -> Path:
+    test_file = temp_path / 'image.tar.gz'
+    with test_file.open('w') as f:
+        f.write('testing')
+    return test_file
+
+
+def test_asset_store_store_retrieve(image_dir, test_image_file) -> None:
+    mock_policy_evaluator = MagicMock()
+    store = AssetStore(mock_policy_evaluator, image_dir)
+
+    asset_id = Identifier('asset:ns:test_asset:ns:site')
+    asset = DataAsset(asset_id, None, str(test_image_file))
+    store.store(asset)
+
+    asset2 = store.retrieve(asset_id, MagicMock())
+    assert asset2.image_location == str(image_dir / f'{asset_id}.tar.gz')
+
+    assert test_image_file.exists()
+    with (image_dir / f'{asset_id}.tar.gz').open('r') as f:
+        assert f.read() == 'testing'
+
+
+def test_asset_store_store_move(image_dir, test_image_file) -> None:
+    mock_policy_evaluator = MagicMock()
+    store = AssetStore(mock_policy_evaluator, image_dir)
+
+    asset = DataAsset(
+            'asset:ns:test_asset:ns:site', None, str(test_image_file))
+    store.store(asset, True)
+
+    assert not test_image_file.exists()
+    with (image_dir / 'asset:ns:test_asset:ns:site.tar.gz').open('r') as f:
+        assert f.read() == 'testing'


### PR DESCRIPTION
This gives the AssetStore the ability to store Docker images, which I think covers task 1347.

I had a look at using the standard nginx Docker image as a base for the data images, but couldn't get it to work quickly. The current setup is also not exactly exotic, just Ubuntu + nginx with WebDAV enabled, which is a configuration I'm familiar with, so I decided to go with that for now. The whole point of a Docker container is of course that it encapsulates the stuff inside, so this can always be changed later if we're so inclined.