### PR TITLE
Add support for exchanging containers between sites

### DIFF
--- a/proof_of_concept/definitions/assets.py
+++ b/proof_of_concept/definitions/assets.py
@@ -31,6 +31,8 @@ class Metadata:
 class Asset:
     """Asset, a representation of a computation or piece of data."""
 
+    KINDS = ('compute', 'data')
+
     def __init__(self, id: Union[str, Identifier], kind: str, data: Any,
                  image_location: Optional[str] = None,
                  metadata: Optional[Metadata] = None
@@ -54,7 +56,7 @@ class Asset:
         """
         if not isinstance(id, Identifier):
             id = Identifier(id)
-        if kind not in ('data', 'compute'):
+        if kind not in self.KINDS:
             raise ValueError(f'Invalid kind {kind}')
         if metadata is None:
             metadata = Metadata(Job.niljob(id), 'dataset')

--- a/proof_of_concept/definitions/assets.py
+++ b/proof_of_concept/definitions/assets.py
@@ -31,18 +31,19 @@ class Metadata:
 class Asset:
     """Asset, a representation of a computation or piece of data."""
 
-    def __init__(self, id: Union[str, Identifier], data: Any,
+    def __init__(self, id: Union[str, Identifier], kind: str, data: Any,
                  image_location: Optional[str] = None,
                  metadata: Optional[Metadata] = None
                  ) -> None:
         """Create an Asset.
 
         Assets may have either a data item (a JSON-serialisable Python
-        value) associated with them, or reference Docker image tarball
+        value) associated with them, or reference a Docker image tarball
         containing data or code.
 
         Args:
             id: Identifier of the asset
+            kind: Either "data" or "compute"
             data: Data related to the asset
             image_location: URL or path to the container image file.
             metadata: Metadata related to the asset. If no metadata is
@@ -53,9 +54,12 @@ class Asset:
         """
         if not isinstance(id, Identifier):
             id = Identifier(id)
+        if kind not in ('data', 'compute'):
+            raise ValueError(f'Invalid kind {kind}')
         if metadata is None:
             metadata = Metadata(Job.niljob(id), 'dataset')
         self.id = id
+        self.kind = kind
         self.data = data
         self.image_location = image_location
         self.metadata = metadata
@@ -63,6 +67,12 @@ class Asset:
 
 class ComputeAsset(Asset):
     """Compute asset, represents a computing step, i.e. software."""
+    def __init__(self, id: Union[str, Identifier], data: Any,
+                 image_location: Optional[str] = None,
+                 metadata: Optional[Metadata] = None
+                 ) -> None:
+        """Create a ComputeAsset (see Asset)."""
+        super().__init__(id, 'compute', data, image_location, metadata)
 
     def run(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Run compute step.
@@ -95,3 +105,9 @@ class ComputeAsset(Asset):
 
 class DataAsset(Asset):
     """Data asset, represents a data set."""
+    def __init__(self, id: Union[str, Identifier], data: Any,
+                 image_location: Optional[str] = None,
+                 metadata: Optional[Metadata] = None
+                 ) -> None:
+        """Create a DataAsset (see Asset)."""
+        super().__init__(id, 'data', data, image_location, metadata)

--- a/proof_of_concept/rest/serialization.py
+++ b/proof_of_concept/rest/serialization.py
@@ -258,18 +258,24 @@ def _serialize_asset(asset: Asset) -> JSON:
     """Serialize an Asset to JSON."""
     return {
             'id': asset.id,
+            'kind': asset.kind,
             'data': asset.data,
+            'image_location': asset.image_location,
             'metadata': _serialize_metadata(asset.metadata)}
 
 
 def _deserialize_asset(user_input: JSON) -> Asset:
     """Deserialize an Asset from JSON."""
-    if user_input['data'] is None:
+    if user_input['kind'] == 'compute':
         return ComputeAsset(
-                user_input['id'], user_input['data'], None,
-                user_input['metadata'])
-    return DataAsset(
-            user_input['id'], user_input['data'], None, user_input['metadata'])
+                user_input['id'], user_input['data'],
+                user_input['image_location'], user_input['metadata'])
+    elif user_input['kind'] == 'data':
+        return DataAsset(
+                user_input['id'], user_input['data'],
+                user_input['image_location'], user_input['metadata'])
+    else:
+        raise RuntimeError('Invalid asset type when deserialising')
 
 
 def _serialize_compute_asset(asset: ComputeAsset) -> JSON:

--- a/proof_of_concept/rest/site_api.yaml
+++ b/proof_of_concept/rest/site_api.yaml
@@ -78,6 +78,46 @@ paths:
               schema:
                 type: string
 
+  /assets/{assetId}/image:
+    get:
+      summary: Download an asset container image
+      operationId: downloadAssetImage
+      parameters:
+        - name: assetId
+          in: path
+          required: true
+          type: string
+          description: The id of the asset whose image to retrieve
+        # TODO: The below will be replaced with an HTTPS client-side
+        # certificate eventually, but we'll just pass it insecurely for now.
+        - name: requester
+          in: query
+          description: Name of the requesting site
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The requested image
+          content:
+            application/x-tar:
+              schema:
+                type: string
+                format: binary
+        "404":
+          description: The asset does not exist or is not available to you.
+          content:
+            text/plain:
+              schema:
+                description: An error message
+                type: string
+        default:
+          description: A technical problem was encountered
+          content:
+            text/plain:
+              schema:
+                type: string
+
   /jobs:
     post:
       summary: Submit a job for the site to run

--- a/proof_of_concept/rest/site_api.yaml
+++ b/proof_of_concept/rest/site_api.yaml
@@ -263,17 +263,19 @@ components:
       type: object
       required:
         - id
+        - kind
         - data
+        - image_location
         - metadata
       properties:
         id:
           description: Identifier for this asset
           type: string
+        kind:
+          description: 'Kind of asset ("compute" or "data")'
+          type: string
         data:
           description: Data related to the asset
-          # TODO: replace this with a URL for a binary image
-          # TODO: probably /assets/{id}/image
-          # TODO: and/or an endpoint for remote access
           # This is currently null for compute objects, and the only way I
           # could get it to match was with this double nullable
           # declaration...
@@ -283,6 +285,10 @@ components:
               items:
                 type: number
               nullable: true
+          nullable: true
+        image_location:
+          description: URL to download the image from
+          type: string
           nullable: true
         metadata:
           type: object

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,3 +62,24 @@ def test_dir():
 def temp_path(tmpdir) -> Path:
     """Returns tmpdir as a standard Path object."""
     return Path(str(tmpdir))
+
+
+@pytest.fixture
+def image_dir(temp_path) -> Path:
+    """Returns a temp directory for asset store images."""
+    path = temp_path / 'store'
+    path.mkdir(exist_ok=True)
+    return path
+
+
+@pytest.fixture
+def test_image_file(temp_path) -> Path:
+    """Returns a path to a mock image file.
+
+    Note: it's just a text file containing 'testing', so the extension
+    is a lie.
+    """
+    test_file = temp_path / 'image.tar.gz'
+    with test_file.open('w') as f:
+        f.write('testing')
+    return test_file

--- a/tests/test_asset_exchange.py
+++ b/tests/test_asset_exchange.py
@@ -50,13 +50,20 @@ def image_server(asset_store):
     thread.join()
 
 
-def test_asset_download(temp_path, asset_id, image_server, caplog):
-    caplog.set_level(logging.DEBUG)
+@pytest.fixture
+def mock_empty_registry_client():
     registry_client = MagicMock()
     empty_ddm = ReplicaUpdate[RegisteredObject](
             0, 0, datetime(2100, 1, 1, 0, 0, 0), set(), set())
     registry_client.get_updates_since = lambda: empty_ddm
-    client = SiteRestClient('site:ns:site', MagicMock(), registry_client)
+    return registry_client
+
+
+def test_asset_download(
+        temp_path, asset_id, image_server, mock_empty_registry_client):
+
+    client = SiteRestClient(
+            'site:ns:site', MagicMock(), mock_empty_registry_client)
 
     download_path = temp_path / 'retrieved_image.tar.gz'
     client.retrieve_asset_image(

--- a/tests/test_asset_exchange.py
+++ b/tests/test_asset_exchange.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+import logging
+from unittest.mock import MagicMock
+from threading import Thread
+from wsgiref.simple_server import WSGIRequestHandler
+
+from falcon import App
+import pytest
+
+from proof_of_concept.components.asset_store import AssetStore
+from proof_of_concept.definitions.assets import DataAsset
+from proof_of_concept.definitions.identifier import Identifier
+from proof_of_concept.definitions.registry import RegisteredObject
+from proof_of_concept.replication import ReplicaUpdate
+from proof_of_concept.rest.client import SiteRestClient
+from proof_of_concept.rest.ddm_site import (
+        AssetImageAccessHandler, ThreadingWSGIServer)
+
+
+@pytest.fixture
+def asset_id():
+    return Identifier('asset:ns:test_asset:ns:site')
+
+
+@pytest.fixture
+def asset_store(temp_path, test_image_file, asset_id):
+    asset_store = AssetStore(MagicMock(), temp_path)
+    asset = DataAsset(asset_id, None, str(test_image_file))
+    asset_store.store(asset)
+    return asset_store
+
+
+@pytest.fixture
+def image_server(asset_store):
+    app = App()
+    asset_image_access = AssetImageAccessHandler(asset_store)
+    app.add_route('/assets/{asset_id}/image', asset_image_access)
+    server = ThreadingWSGIServer(('0.0.0.0', 0), WSGIRequestHandler)
+    server.set_app(app)
+
+    thread = Thread(
+            target=server.serve_forever,
+            name='TestServer')
+    thread.start()
+
+    yield f'http://{server.server_name}:{server.server_port}'
+
+    server.shutdown()
+    server.server_close()
+    thread.join()
+
+
+def test_asset_download(temp_path, asset_id, image_server, caplog):
+    caplog.set_level(logging.DEBUG)
+    registry_client = MagicMock()
+    empty_ddm = ReplicaUpdate[RegisteredObject](
+            0, 0, datetime(2100, 1, 1, 0, 0, 0), set(), set())
+    registry_client.get_updates_since = lambda: empty_ddm
+    client = SiteRestClient('site:ns:site', MagicMock(), registry_client)
+
+    download_path = temp_path / 'retrieved_image.tar.gz'
+    client.retrieve_asset_image(
+            f'{image_server}/assets/{asset_id}/image', download_path)
+
+    with download_path.open('r') as f:
+        image_data = f.read()
+
+    assert image_data == 'testing'

--- a/tests/test_asset_store.py
+++ b/tests/test_asset_store.py
@@ -8,21 +8,6 @@ from proof_of_concept.definitions.assets import DataAsset
 from proof_of_concept.definitions.identifier import Identifier
 
 
-@pytest.fixture
-def image_dir(temp_path) -> Path:
-    path = temp_path / 'store'
-    path.mkdir(exist_ok=True)
-    return path
-
-
-@pytest.fixture
-def test_image_file(temp_path) -> Path:
-    test_file = temp_path / 'image.tar.gz'
-    with test_file.open('w') as f:
-        f.write('testing')
-    return test_file
-
-
 def test_asset_store_store_retrieve(image_dir, test_image_file) -> None:
     mock_policy_evaluator = MagicMock()
     store = AssetStore(mock_policy_evaluator, image_dir)


### PR DESCRIPTION
This adds a new endpoint to the site REST API that allows downloading a container image for a container. It's a separate endpoint (as opposed to serialising the container inside the Asset object) because the image is a large (hundreds of megabytes at least) binary blob. A separate endpoint avoids inefficient encodings and makes it easy to download the image straight to disk. Also, in the future we may want to use a network connection instead of downloading the image, so it needs to be a separate step.