### PR TITLE
1721: policy management API

### DIFF
--- a/proof_of_concept/rest/internal_client.py
+++ b/proof_of_concept/rest/internal_client.py
@@ -5,6 +5,7 @@ from urllib.parse import quote
 import requests
 
 from proof_of_concept.definitions.assets import Asset
+from proof_of_concept.definitions.policy import Rule
 from proof_of_concept.rest.serialization import serialize
 
 
@@ -40,3 +41,14 @@ class InternalSiteRestClient:
                         data=f)
                 if r.status_code != 204:
                     raise RuntimeError('Error uploading asset image to site')
+
+    def add_rule(self, rule: Rule) -> None:
+        """Adds a rule to the site's policy store.
+
+        Args:
+            rule: The rule to add.
+
+        """
+        r = requests.post(f'{self._endpoint}/rules', json=serialize(rule))
+        if r.status_code != 200:
+            raise RuntimeError(f'Error adding rule to site: {r.text}')

--- a/proof_of_concept/rest/replication.py
+++ b/proof_of_concept/rest/replication.py
@@ -85,9 +85,7 @@ class ReplicationRestClient(IReplicationService[T]):
         r = self._retry_http_get(params)
 
         update_json = r.json()
-        logger.info(f'Replication update: {update_json}')
         self._validator.validate(self.UpdateType.__name__, update_json)
-        logger.info(f'Validated against {self.UpdateType.__name__}')
         return deserialize(self.UpdateType, update_json)
 
     @retry(                                             # type: ignore

--- a/proof_of_concept/rest/site_api.yaml
+++ b/proof_of_concept/rest/site_api.yaml
@@ -245,6 +245,13 @@ components:
           description: Id of the collection the result is in
           type: string
 
+    Rule:
+      oneOf:
+        - $ref: '#/components/schemas/InAssetCollection'
+        - $ref: '#/components/schemas/InPartyCollection'
+        - $ref: '#/components/schemas/MayAccess'
+        - $ref: '#/components/schemas/ResultOfIn'
+
     PolicyUpdate:
       type: object
       required:

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -166,7 +166,7 @@ def test_container_step(
     # create site
     site = Site(
             'test_site', 'party:ns:test_party', 'ns',
-            [], rules, registry_client)
+            [], [], registry_client)
 
     site_server = SiteServer(SiteRestApi(
         site.policy_store, site.store, site.runner))
@@ -174,6 +174,9 @@ def test_container_step(
     internal_client = InternalSiteRestClient(site_server.internal_endpoint)
     for asset in assets:
         internal_client.store_asset(asset)
+
+    for rule in rules:
+        internal_client.add_rule(rule)
 
     registry_client.register_site(
         SiteDescription(

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -61,7 +61,7 @@ def create_sites(
     return {
             site_name: Site(
                 site_name, desc['owner'], desc['namespace'], [],
-                desc['rules'], registry_client)
+                [], registry_client)
             for site_name, desc in site_descriptions.items()}
 
 
@@ -81,6 +81,16 @@ def upload_assets(
         client = InternalSiteRestClient(server.internal_endpoint)
         for asset in desc['assets']:
             client.store_asset(asset)
+
+
+def add_rules(
+        site_descriptions: Dict[str, Any], servers: Dict[str, Site]) -> None:
+    """Add rules to sites using internal API."""
+    for site_name, desc in site_descriptions.items():
+        server = servers[site_name]
+        client = InternalSiteRestClient(server.internal_endpoint)
+        for rule in desc['rules']:
+            client.add_rule(rule)
 
 
 def register_sites(
@@ -130,6 +140,7 @@ def run_scenario(scenario: Dict[str, Any]) -> Dict[str, Any]:
     sites = create_sites(registry_client, scenario['sites'])
     servers = create_servers(sites)
     upload_assets(scenario['sites'], servers)
+    add_rules(scenario['sites'], servers)
     register_sites(registry_client, sites, servers)
 
     result = sites[scenario['user_site']].run_job(scenario['job'])


### PR DESCRIPTION
Let's add more APIs! This is the simplest possible API for managing policies, it only allows you to add rules. That's enough for our experiments, so we'll leave listing and deleting them for some other time.