### PR TITLE
Task 1258: Split off REST bits from RegistryClient

### DIFF
--- a/proof_of_concept/components/ddm_site.py
+++ b/proof_of_concept/components/ddm_site.py
@@ -32,8 +32,6 @@ class Site:
             rules: List[Rule], registry_client: RegistryClient) -> None:
         """Create a Site.
 
-        Also registers its runner and store in the global registry.
-
         Args:
             name: Name of the site
             owner: Party which owns this site.

--- a/proof_of_concept/components/registry_client.py
+++ b/proof_of_concept/components/registry_client.py
@@ -1,50 +1,41 @@
 """Functionality for connecting to the central registry."""
 from pathlib import Path
-import requests
 from typing import Any, Callable, List, Optional, Set
 
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
-import ruamel.yaml as yaml
 
 from proof_of_concept.definitions.identifier import Identifier
+from proof_of_concept.definitions.interfaces import IRegistry
 from proof_of_concept.definitions.registry import (
         PartyDescription, RegisteredObject, SiteDescription)
-from proof_of_concept.rest.serialization import serialize
 from proof_of_concept.replication import Replica
-from proof_of_concept.rest.replication import RegistryRestClient
-from proof_of_concept.rest.validation import Validator
 
 
 RegistryCallback = Callable[
         [Set[RegisteredObject], Set[RegisteredObject]], None]
 
 
-class RegistryReplica(Replica[RegisteredObject]):
+class _RegistryReplica(Replica[RegisteredObject]):
     """Local replica of the global registry."""
     pass
 
 
 class RegistryClient:
     """Local interface to the global registry."""
-    def __init__(self, endpoint: str = 'http://localhost:4413') -> None:
-        """Create a RegistryClient."""
-        self._registry_endpoint = endpoint
+    def __init__(self, registry: IRegistry) -> None:
+        """Create a RegistryClient.
 
+        Note that this class can use either a Registry object to
+        call directly, or a RegistryRestClient to connect to a
+        registry via a REST API.
+
+        Args:
+            registry: The registry to connect to.
+        """
+        self._registry = registry
         self._callbacks = list()    # type: List[RegistryCallback]
-
-        # Set up connection to registry
-        registry_api_file = (
-                Path(__file__).parents[1] / 'rest' / 'registry_api.yaml')
-        with open(registry_api_file, 'r') as f:
-            registry_api_def = yaml.safe_load(f.read())
-
-        registry_validator = Validator(registry_api_def)
-
-        registry_client = RegistryRestClient(
-                self._registry_endpoint + '/updates', registry_validator)
-
-        self._registry_replica = RegistryReplica(
-                registry_client, on_update=self._on_registry_update)
+        self._registry_replica = _RegistryReplica(
+                registry, on_update=self._on_registry_update)
 
         # Get initial data
         self._registry_replica.update()
@@ -81,9 +72,7 @@ class RegistryClient:
             description: Description of the party.
 
         """
-        requests.post(
-                self._registry_endpoint + '/parties',
-                json=serialize(description))
+        self._registry.register_party(description)
 
     def deregister_party(self, party: Identifier) -> None:
         """Deregister a party with the Registry.
@@ -91,10 +80,11 @@ class RegistryClient:
         Args:
             party: The party to deregister.
 
+        Raises:
+            KeyError: If the party could not be found
+
         """
-        r = requests.delete(f'{self._registry_endpoint}/parties/{party}')
-        if r.status_code == 404:
-            raise KeyError('Party not found')
+        self._registry.deregister_party(party)
 
     def register_site(self, description: SiteDescription) -> None:
         """Register a site with the Registry.
@@ -103,9 +93,7 @@ class RegistryClient:
             description: Description of the site.
 
         """
-        requests.post(
-                self._registry_endpoint + '/sites',
-                json=serialize(description))
+        self._registry.register_site(description)
 
     def deregister_site(self, site: Identifier) -> None:
         """Deregister a site with the Registry.
@@ -113,10 +101,11 @@ class RegistryClient:
         Args:
             site: The site to deregister.
 
+        Raises:
+            KeyError: If the site could not be found
+
         """
-        r = requests.delete(f'{self._registry_endpoint}/sites/{site}')
-        if r.status_code == 404:
-            raise KeyError('Site not found')
+        self._registry.deregister_site(site)
 
     def get_public_key_for_ns(self, namespace: str) -> RSAPublicKey:
         """Get the public key of the owner of a namespace."""

--- a/proof_of_concept/components/registry_client.py
+++ b/proof_of_concept/components/registry_client.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, List, Optional, Set
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from proof_of_concept.definitions.identifier import Identifier
-from proof_of_concept.definitions.interfaces import IRegistry
+from proof_of_concept.definitions.interfaces import IRegistryService
 from proof_of_concept.definitions.registry import (
         PartyDescription, RegisteredObject, SiteDescription)
 from proof_of_concept.replication import Replica
@@ -21,8 +21,13 @@ class _RegistryReplica(Replica[RegisteredObject]):
 
 
 class RegistryClient:
-    """Local interface to the global registry."""
-    def __init__(self, registry: IRegistry) -> None:
+    """Local client for the global registry.
+
+    This provides read-only access to the global registry via several
+    utility functions, based on a local replica it keeps.
+
+    """
+    def __init__(self, registry: IRegistryService) -> None:
         """Create a RegistryClient.
 
         Note that this class can use either a Registry object to
@@ -32,7 +37,6 @@ class RegistryClient:
         Args:
             registry: The registry to connect to.
         """
-        self._registry = registry
         self._callbacks = list()    # type: List[RegistryCallback]
         self._registry_replica = _RegistryReplica(
                 registry, on_update=self._on_registry_update)
@@ -64,48 +68,6 @@ class RegistryClient:
 
         """
         self._registry_replica.update()
-
-    def register_party(self, description: PartyDescription) -> None:
-        """Register a party with the Registry.
-
-        Args:
-            description: Description of the party.
-
-        """
-        self._registry.register_party(description)
-
-    def deregister_party(self, party: Identifier) -> None:
-        """Deregister a party with the Registry.
-
-        Args:
-            party: The party to deregister.
-
-        Raises:
-            KeyError: If the party could not be found
-
-        """
-        self._registry.deregister_party(party)
-
-    def register_site(self, description: SiteDescription) -> None:
-        """Register a site with the Registry.
-
-        Args:
-            description: Description of the site.
-
-        """
-        self._registry.register_site(description)
-
-    def deregister_site(self, site: Identifier) -> None:
-        """Deregister a site with the Registry.
-
-        Args:
-            site: The site to deregister.
-
-        Raises:
-            KeyError: If the site could not be found
-
-        """
-        self._registry.deregister_site(site)
 
     def get_public_key_for_ns(self, namespace: str) -> RSAPublicKey:
         """Get the public key of the owner of a namespace."""

--- a/proof_of_concept/definitions/interfaces.py
+++ b/proof_of_concept/definitions/interfaces.py
@@ -6,6 +6,8 @@ from typing import Dict, Generic, Iterable, Set, Type, TypeVar
 from proof_of_concept.definitions.identifier import Identifier
 from proof_of_concept.definitions.assets import Asset, ComputeAsset
 from proof_of_concept.definitions.policy import Rule
+from proof_of_concept.definitions.registry import (
+        PartyDescription, RegisteredObject, SiteDescription)
 from proof_of_concept.definitions.workflows import (
         ExecutionRequest, Job, WorkflowStep)
 
@@ -44,6 +46,47 @@ class IReplicationService(Generic[T]):
 
         Return:
             An update from the given version to a newer version.
+        """
+        raise NotImplementedError()
+
+
+class IRegistry(IReplicationService[RegisteredObject]):
+    """Interface for the central registry.
+
+    This is equivalent to the registry REST API, and is implemented
+    by the Registry class and the RegistryRestClient class.
+    """
+    def register_party(
+            self, description: PartyDescription) -> None:
+        """Register a party with the DDM.
+
+        Args:
+            description: A description of the party
+        """
+        raise NotImplementedError()
+
+    def deregister_party(self, party_id: Identifier) -> None:
+        """Deregister a party with the DDM.
+
+        Args:
+            party_id: Identifier of the party to deregister.
+        """
+        raise NotImplementedError()
+
+    def register_site(self, description: SiteDescription) -> None:
+        """Register a Site with the Registry.
+
+        Args:
+            description: Description of the site.
+
+        """
+        raise NotImplementedError()
+
+    def deregister_site(self, site_id: Identifier) -> None:
+        """Deregister a site with the DDM.
+
+        Args:
+            site_id: Identifer of the site to deregister.
         """
         raise NotImplementedError()
 

--- a/proof_of_concept/definitions/interfaces.py
+++ b/proof_of_concept/definitions/interfaces.py
@@ -50,12 +50,11 @@ class IReplicationService(Generic[T]):
         raise NotImplementedError()
 
 
-class IRegistry(IReplicationService[RegisteredObject]):
-    """Interface for the central registry.
+IRegistryService = IReplicationService[RegisteredObject]
 
-    This is equivalent to the registry REST API, and is implemented
-    by the Registry class and the RegistryRestClient class.
-    """
+
+class IRegistration:
+    """Interface for registering with the central registry."""
     def register_party(
             self, description: PartyDescription) -> None:
         """Register a party with the DDM.

--- a/proof_of_concept/registry/registry.py
+++ b/proof_of_concept/registry/registry.py
@@ -3,7 +3,8 @@ import logging
 from typing import Any, Dict, Optional, Type, TypeVar
 
 from proof_of_concept.definitions.identifier import Identifier
-from proof_of_concept.definitions.interfaces import IAssetStore
+from proof_of_concept.definitions.interfaces import (
+        IAssetStore, IRegistry, IReplicaUpdate)
 from proof_of_concept.definitions.registry import (
         PartyDescription, RegisteredObject, SiteDescription)
 from proof_of_concept.registry.replication import RegistryStore, RegistryUpdate
@@ -16,7 +17,7 @@ logger = logging.getLogger(__name__)
 _ReplicatedClass = TypeVar('_ReplicatedClass', bound=RegisteredObject)
 
 
-class Registry:
+class Registry(IRegistry):
     """Global registry of remote-accessible things.
 
     Registers runners, stores, and assets. In a real system, runners
@@ -28,7 +29,21 @@ class Registry:
         self._asset_locations = dict()           # type: Dict[Identifier, str]
 
         archive = ReplicableArchive[RegisteredObject]()
-        self.store = RegistryStore(archive, 0.1)
+        self._store = RegistryStore(archive, 0.1)
+
+    def get_updates_since(
+            self, from_version: int) -> IReplicaUpdate[RegisteredObject]:
+        """Return a set of objects modified since the given version.
+
+        Args:
+            from_version: A version received from a previous call to
+                    this function, or 0 to get an update for a
+                    fresh replica.
+
+        Return:
+            An update from the given version to a newer version.
+        """
+        return self._store.get_updates_since(from_version)
 
     def register_party(
             self, description: PartyDescription) -> None:
@@ -41,7 +56,7 @@ class Registry:
             raise RuntimeError(
                     f'There is already a party called {description.id}')
 
-        self.store.insert(description)
+        self._store.insert(description)
         logger.info(f'Registered party {description}')
 
     def deregister_party(self, party_id: Identifier) -> None:
@@ -53,7 +68,7 @@ class Registry:
         description = self._get_object(PartyDescription, 'id', party_id)
         if description is None:
             raise KeyError('Party not found')
-        self.store.delete(description)
+        self._store.delete(description)
 
     def register_site(self, description: SiteDescription) -> None:
         """Register a Site with the Registry.
@@ -76,7 +91,7 @@ class Registry:
         if admin is None:
             raise RuntimeError(f'Party {description.admin_id} not found')
 
-        self.store.insert(description)
+        self._store.insert(description)
         logger.info(f'{self} Registered site {description}')
 
     def deregister_site(self, site_id: Identifier) -> None:
@@ -88,7 +103,7 @@ class Registry:
         description = self._get_object(SiteDescription, 'id', site_id)
         if description is None:
             raise KeyError('Site not found')
-        self.store.delete(description)
+        self._store.delete(description)
 
     def _get_object(
             self, typ: Type[_ReplicatedClass], attr_name: str, value: Any
@@ -113,7 +128,7 @@ class Registry:
                 in the store which does not have an attribute named
                 `attr_name`.
         """
-        for o in self.store.objects():
+        for o in self._store.objects():
             if isinstance(o, typ):
                 if getattr(o, attr_name) == value:
                     return o

--- a/proof_of_concept/registry/registry.py
+++ b/proof_of_concept/registry/registry.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional, Type, TypeVar
 
 from proof_of_concept.definitions.identifier import Identifier
 from proof_of_concept.definitions.interfaces import (
-        IAssetStore, IRegistry, IReplicaUpdate)
+        IAssetStore, IRegistration, IRegistryService, IReplicaUpdate)
 from proof_of_concept.definitions.registry import (
         PartyDescription, RegisteredObject, SiteDescription)
 from proof_of_concept.registry.replication import RegistryStore, RegistryUpdate
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 _ReplicatedClass = TypeVar('_ReplicatedClass', bound=RegisteredObject)
 
 
-class Registry(IRegistry):
+class Registry(IRegistration, IRegistryService):
     """Global registry of remote-accessible things.
 
     Registers runners, stores, and assets. In a real system, runners

--- a/proof_of_concept/rest/ddm_site.py
+++ b/proof_of_concept/rest/ddm_site.py
@@ -25,6 +25,7 @@ from proof_of_concept.definitions.interfaces import IAssetStore, IStepRunner
 from proof_of_concept.definitions.policy import Rule
 from proof_of_concept.definitions.workflows import ExecutionRequest, Job
 from proof_of_concept.policy.replication import PolicyStore
+from proof_of_concept.rest.registry_client import RegistryRestClient
 from proof_of_concept.rest.replication import ReplicationHandler
 from proof_of_concept.rest.serialization import deserialize, serialize
 from proof_of_concept.rest.validation import site_validator, ValidationError
@@ -524,7 +525,8 @@ def wsgi_app() -> App:
     """Creates a WSGI app for a WSGI runner."""
     settings = load_settings(default_config_location)
 
-    registry_client = RegistryClient(settings.registry_endpoint)
+    registry_rest_client = RegistryRestClient(settings.registry_endpoint)
+    registry_client = RegistryClient(registry_rest_client)
     site = Site(
             settings.name, settings.owner, settings.namespace, [], [],
             registry_client)

--- a/proof_of_concept/rest/registry.py
+++ b/proof_of_concept/rest/registry.py
@@ -165,8 +165,7 @@ class RegistryRestApi:
         self.app.add_route('/sites', site_registration)
         self.app.add_route('/sites/{id}', site_registration)
 
-        registry_replication = ReplicationHandler[RegisteredObject](
-                registry.store)
+        registry_replication = ReplicationHandler[RegisteredObject](registry)
         self.app.add_route('/updates', registry_replication)
 
 

--- a/proof_of_concept/rest/registry_client.py
+++ b/proof_of_concept/rest/registry_client.py
@@ -1,0 +1,101 @@
+"""Client for the registry REST API."""
+from pathlib import Path
+from typing import cast
+
+import requests
+import ruamel.yaml as yaml
+
+from proof_of_concept.definitions.identifier import Identifier
+from proof_of_concept.definitions.interfaces import (
+        IRegistry, IReplicaUpdate)
+from proof_of_concept.definitions.registry import (
+        PartyDescription, RegisteredObject, SiteDescription)
+from proof_of_concept.rest.replication import ReplicationRestClient
+from proof_of_concept.rest.validation import Validator
+from proof_of_concept.registry.replication import RegistryUpdate
+from proof_of_concept.rest.serialization import serialize
+
+
+class _ReplicationRestClient(ReplicationRestClient[RegisteredObject]):
+    """A replication client for replicating the registry."""
+    UpdateType = RegistryUpdate
+
+
+class RegistryRestClient(IRegistry):
+    """REST client for the global registry."""
+    def __init__(self, endpoint: str = 'http://localhost:4413') -> None:
+        """Create a RegistryRestClient."""
+        self._registry_endpoint = endpoint
+
+        # Set up connection to registry
+        registry_api_file = (
+                Path(__file__).parents[1] / 'rest' / 'registry_api.yaml')
+        with open(registry_api_file, 'r') as f:
+            registry_api_def = yaml.safe_load(f.read())
+
+        registry_validator = Validator(registry_api_def)
+
+        self._registry_client = _ReplicationRestClient(
+                self._registry_endpoint + '/updates', registry_validator)
+
+    def get_updates_since(self, from_version: int) -> RegistryUpdate:
+        """Return a set of objects modified since the given version.
+
+        Args:
+            from_version: A version received from a previous call to
+                    this function, or 0 to get an update for a
+                    fresh replica.
+
+        Return:
+            An update from the given version to a newer version.
+        """
+        # This is always a RegistryUpdate, because we set UpdateType in
+        # _ReplicationRestClient above. But mypy doesn't quite let us
+        # write the type annotations to tell it that, so we cast.
+        return cast(
+                RegistryUpdate,
+                self._registry_client.get_updates_since(from_version))
+
+    def register_party(self, description: PartyDescription) -> None:
+        """Register a party with the Registry.
+
+        Args:
+            description: Description of the party.
+
+        """
+        requests.post(
+                self._registry_endpoint + '/parties',
+                json=serialize(description))
+
+    def deregister_party(self, party: Identifier) -> None:
+        """Deregister a party with the Registry.
+
+        Args:
+            party: The party to deregister.
+
+        """
+        r = requests.delete(f'{self._registry_endpoint}/parties/{party}')
+        if r.status_code == 404:
+            raise KeyError('Party not found')
+
+    def register_site(self, description: SiteDescription) -> None:
+        """Register a site with the Registry.
+
+        Args:
+            description: Description of the site.
+
+        """
+        requests.post(
+                self._registry_endpoint + '/sites',
+                json=serialize(description))
+
+    def deregister_site(self, site: Identifier) -> None:
+        """Deregister a site with the Registry.
+
+        Args:
+            site: The site to deregister.
+
+        """
+        r = requests.delete(f'{self._registry_endpoint}/sites/{site}')
+        if r.status_code == 404:
+            raise KeyError('Site not found')

--- a/proof_of_concept/rest/registry_client.py
+++ b/proof_of_concept/rest/registry_client.py
@@ -7,7 +7,7 @@ import ruamel.yaml as yaml
 
 from proof_of_concept.definitions.identifier import Identifier
 from proof_of_concept.definitions.interfaces import (
-        IRegistry, IReplicaUpdate)
+        IRegistration, IRegistryService, IReplicaUpdate)
 from proof_of_concept.definitions.registry import (
         PartyDescription, RegisteredObject, SiteDescription)
 from proof_of_concept.rest.replication import ReplicationRestClient
@@ -21,22 +21,30 @@ class _ReplicationRestClient(ReplicationRestClient[RegisteredObject]):
     UpdateType = RegistryUpdate
 
 
-class RegistryRestClient(IRegistry):
-    """REST client for the global registry."""
-    def __init__(self, endpoint: str = 'http://localhost:4413') -> None:
-        """Create a RegistryRestClient."""
-        self._registry_endpoint = endpoint
+class RegistryRestClient(IRegistryService):
+    """REST client for the global registry.
 
-        # Set up connection to registry
+    This connects to the read-only replication part of the registry
+    REST API.
+
+    """
+    def __init__(self, endpoint: str = 'http://localhost:4413') -> None:
+        """Create a RegistryRestClient.
+
+        Args:
+            endpoint: URL of the endpoint to connect to.
+
+        """
         registry_api_file = (
                 Path(__file__).parents[1] / 'rest' / 'registry_api.yaml')
+
         with open(registry_api_file, 'r') as f:
             registry_api_def = yaml.safe_load(f.read())
 
         registry_validator = Validator(registry_api_def)
 
         self._registry_client = _ReplicationRestClient(
-                self._registry_endpoint + '/updates', registry_validator)
+                endpoint + '/updates', registry_validator)
 
     def get_updates_since(self, from_version: int) -> RegistryUpdate:
         """Return a set of objects modified since the given version.
@@ -55,6 +63,17 @@ class RegistryRestClient(IRegistry):
         return cast(
                 RegistryUpdate,
                 self._registry_client.get_updates_since(from_version))
+
+
+class RegistrationRestClient(IRegistration):
+    """REST client for registering sites and parties.
+
+    This connects to the registration part of the registry REST API.
+
+    """
+    def __init__(self, endpoint: str = 'http://localhost:4413') -> None:
+        """Create a RegistrationRestClient."""
+        self._registry_endpoint = endpoint
 
     def register_party(self, description: PartyDescription) -> None:
         """Register a party with the Registry.

--- a/proof_of_concept/rest/replication.py
+++ b/proof_of_concept/rest/replication.py
@@ -100,8 +100,3 @@ class ReplicationRestClient(IReplicationService[T]):
 class PolicyRestClient(ReplicationRestClient[Rule]):
     """A client for policy servers."""
     UpdateType = PolicyUpdate
-
-
-class RegistryRestClient(ReplicationRestClient[RegisteredObject]):
-    """A client for the registry."""
-    UpdateType = RegistryUpdate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,11 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.backends import default_backend
 import pytest
 
+from proof_of_concept.components.registry_client import RegistryClient
 from proof_of_concept.registry.registry import Registry
 from proof_of_concept.rest.registry import RegistryRestApi, RegistryServer
+from proof_of_concept.rest.registry_client import RegistryRestClient
+
 
 log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 logging.basicConfig(level=logging.INFO, format=log_format)
@@ -41,6 +44,17 @@ def registry_server():
     yield
 
     server.close()
+
+
+@pytest.fixture
+def registry_client():
+    """Create a registry REST API client.
+
+    Connects to the default service endpoint.
+
+    """
+    registry_rest_client = RegistryRestClient()
+    return RegistryClient(registry_rest_client)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,8 @@ import pytest
 from proof_of_concept.components.registry_client import RegistryClient
 from proof_of_concept.registry.registry import Registry
 from proof_of_concept.rest.registry import RegistryRestApi, RegistryServer
-from proof_of_concept.rest.registry_client import RegistryRestClient
+from proof_of_concept.rest.registry_client import (
+        RegistrationRestClient, RegistryRestClient)
 
 
 log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
@@ -48,13 +49,23 @@ def registry_server():
 
 @pytest.fixture
 def registry_client():
-    """Create a registry REST API client.
+    """Create a registry REST API replication client.
 
     Connects to the default service endpoint.
 
     """
     registry_rest_client = RegistryRestClient()
     return RegistryClient(registry_rest_client)
+
+
+@pytest.fixture
+def registration_client():
+    """Create a registration REST API registration client.
+
+    Connects to the default service endpoint.
+
+    """
+    return RegistrationRestClient()
 
 
 @pytest.fixture

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -120,11 +120,10 @@ def compute_asset_tar(dcli, docker_dir):
         'proof_of_concept.components.domain_administrator.OUTPUT_ASSET_ID',
         Identifier('asset:ns:output_base:ns:test_site'))
 def test_container_step(
-        registry_server, data_asset_tars, compute_asset_tar, caplog):
+        registry_server, registry_client, data_asset_tars, compute_asset_tar,
+        caplog):
 
     caplog.set_level(logging.DEBUG)
-
-    registry_client = RegistryClient()
 
     # create party
     party_key = generate_private_key(

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -10,7 +10,6 @@ import pytest
 import time
 
 from proof_of_concept.components.ddm_site import Site
-from proof_of_concept.components.registry_client import RegistryClient
 from proof_of_concept.definitions.assets import ComputeAsset, DataAsset
 from proof_of_concept.definitions.identifier import Identifier
 from proof_of_concept.definitions.registry import (
@@ -120,8 +119,8 @@ def compute_asset_tar(dcli, docker_dir):
         'proof_of_concept.components.domain_administrator.OUTPUT_ASSET_ID',
         Identifier('asset:ns:output_base:ns:test_site'))
 def test_container_step(
-        registry_server, registry_client, data_asset_tars, compute_asset_tar,
-        caplog):
+        registry_server, registry_client, registration_client,
+        data_asset_tars, compute_asset_tar, caplog):
 
     caplog.set_level(logging.DEBUG)
 
@@ -129,7 +128,7 @@ def test_container_step(
     party_key = generate_private_key(
             public_exponent=65537, key_size=2048, backend=default_backend())
 
-    registry_client.register_party(
+    registration_client.register_party(
             PartyDescription('party:ns:test_party', party_key.public_key()))
 
     # create assets
@@ -178,7 +177,7 @@ def test_container_step(
     for rule in rules:
         internal_client.add_rule(rule)
 
-    registry_client.register_site(
+    registration_client.register_site(
         SiteDescription(
                 site.id, site.owner, site.administrator,
                 site_server.external_endpoint,
@@ -203,6 +202,6 @@ def test_container_step(
         result = site.run_job(Job(workflow, inputs))
     finally:
         site_server.close()
-        registry_client.deregister_site(site.id)
-        registry_client.deregister_party('party:ns:test_party')
+        registration_client.deregister_site(site.id)
+        registration_client.deregister_party('party:ns:test_party')
         site.close()

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -133,12 +133,12 @@ def deregister_parties(
         registry_client.deregister_party(party_id)
 
 
-def run_scenario(scenario: Dict[str, Any]) -> Dict[str, Any]:
+def run_scenario(
+        scenario: Dict[str, Any], registry_client: RegistryClient
+        ) -> Dict[str, Any]:
     logger.info('Running test scenario on behalf of {}'.format(
         scenario['user_site']))
     logger.info('Job:\n{}'.format(indent(str(scenario["job"]), " "*4)))
-
-    registry_client = RegistryClient()
 
     parties = create_parties(scenario['sites'])
     register_parties(registry_client, parties)
@@ -165,7 +165,7 @@ def run_scenario(scenario: Dict[str, Any]) -> Dict[str, Any]:
     return result.outputs
 
 
-def test_pii(registry_server):
+def test_pii(registry_server, registry_client):
     scenario = dict()     # type: Dict[str, Any]
 
     scenario['rules-party1'] = [
@@ -321,11 +321,11 @@ def test_pii(registry_server):
     scenario['job'] = Job(workflow, inputs)
     scenario['user_site'] = 'site2'
 
-    output = run_scenario(scenario)
+    output = run_scenario(scenario, registry_client)
     assert output['result'].data == 12.5
 
 
-def test_saas_with_data(registry_server):
+def test_saas_with_data(registry_server, registry_client):
     scenario = dict()     # type: Dict[str, Any]
 
     scenario['rules-party1'] = [
@@ -414,5 +414,5 @@ def test_saas_with_data(registry_server):
     scenario['job'] = Job(workflow, inputs)
     scenario['user_site'] = 'site1'
 
-    output = run_scenario(scenario)
+    output = run_scenario(scenario, registry_client)
     assert output['y'].data == 45

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__file__)
 def create_parties(
         site_descriptions: Dict[str, Any]
         ) -> Dict[str, RSAPrivateKey]:
-    """Creates parties with private keys and registers them."""
+    """Creates parties with private keys."""
     return {
             desc['owner']: generate_private_key(
                 public_exponent=65537,

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -18,6 +18,7 @@ from proof_of_concept.policy.rules import (
     ResultOfComputeIn)
 from proof_of_concept.rest.ddm_site import SiteRestApi, SiteServer
 from proof_of_concept.rest.internal_client import InternalSiteRestClient
+from proof_of_concept.rest.registry_client import RegistrationRestClient
 
 
 logger = logging.getLogger(__file__)
@@ -36,11 +37,12 @@ def create_parties(
 
 
 def register_parties(
-        registry_client: RegistryClient, parties: Dict[str, RSAPrivateKey]
+        registration_client: RegistrationRestClient,
+        parties: Dict[str, RSAPrivateKey]
         ) -> None:
     """Register parties with their public keys."""
     for party_id, private_key in parties.items():
-        registry_client.register_party(
+        registration_client.register_party(
                 PartyDescription(party_id, private_key.public_key()))
 
 
@@ -101,11 +103,11 @@ def add_rules(
 
 
 def register_sites(
-        registry_client: RegistryClient, sites: Dict[str, Site],
+        registration_client: RegistrationRestClient, sites: Dict[str, Site],
         servers: Dict[str, SiteServer]) -> None:
     """Register sites with the registry."""
     for site_name, site in sites.items():
-        registry_client.register_site(
+        registration_client.register_site(
                 SiteDescription(
                     site.id, site.owner, site.administrator,
                     servers[site_name].external_endpoint,
@@ -119,29 +121,32 @@ def stop_servers(servers: Dict[str, SiteServer]):
 
 
 def deregister_sites(
-        registry_client: RegistryClient, sites: Dict[str, Site]) -> None:
+        registration_client: RegistrationRestClient, sites: Dict[str, Site]
+        ) -> None:
     """Deregisters sites from the registry."""
     for site in sites.values():
-        registry_client.deregister_site(site.id)
+        registration_client.deregister_site(site.id)
 
 
 def deregister_parties(
-        registry_client: RegistryClient, parties: Dict[str, RSAPrivateKey]
+        registration_client: RegistrationRestClient,
+        parties: Dict[str, RSAPrivateKey]
         ) -> None:
     """Deregisters parties from the registry."""
     for party_id in parties:
-        registry_client.deregister_party(party_id)
+        registration_client.deregister_party(party_id)
 
 
 def run_scenario(
-        scenario: Dict[str, Any], registry_client: RegistryClient
+        scenario: Dict[str, Any], registry_client: RegistryClient,
+        registration_client: RegistrationRestClient
         ) -> Dict[str, Any]:
     logger.info('Running test scenario on behalf of {}'.format(
         scenario['user_site']))
     logger.info('Job:\n{}'.format(indent(str(scenario["job"]), " "*4)))
 
     parties = create_parties(scenario['sites'])
-    register_parties(registry_client, parties)
+    register_parties(registration_client, parties)
 
     sign_rules(scenario['sites'], parties)
     sites = create_sites(registry_client, scenario['sites'])
@@ -149,7 +154,7 @@ def run_scenario(
     clients = create_clients(servers, sites)
     upload_assets(scenario['sites'], clients)
     add_rules(scenario['sites'], clients)
-    register_sites(registry_client, sites, servers)
+    register_sites(registration_client, sites, servers)
 
     client = clients[scenario['user_site']]
     job_id = client.submit_job(scenario['job'])
@@ -158,14 +163,14 @@ def run_scenario(
     result = client.get_job_result(job_id)
 
     stop_servers(servers)
-    deregister_sites(registry_client, sites)
-    deregister_parties(registry_client, parties)
+    deregister_sites(registration_client, sites)
+    deregister_parties(registration_client, parties)
 
     logger.info(f'Result: {result.outputs}')
     return result.outputs
 
 
-def test_pii(registry_server, registry_client):
+def test_pii(registry_server, registry_client, registration_client):
     scenario = dict()     # type: Dict[str, Any]
 
     scenario['rules-party1'] = [
@@ -321,11 +326,11 @@ def test_pii(registry_server, registry_client):
     scenario['job'] = Job(workflow, inputs)
     scenario['user_site'] = 'site2'
 
-    output = run_scenario(scenario, registry_client)
+    output = run_scenario(scenario, registry_client, registration_client)
     assert output['result'].data == 12.5
 
 
-def test_saas_with_data(registry_server, registry_client):
+def test_saas_with_data(registry_server, registry_client, registration_client):
     scenario = dict()     # type: Dict[str, Any]
 
     scenario['rules-party1'] = [
@@ -414,5 +419,5 @@ def test_saas_with_data(registry_server, registry_client):
     scenario['job'] = Job(workflow, inputs)
     scenario['user_site'] = 'site1'
 
-    output = run_scenario(scenario, registry_client)
+    output = run_scenario(scenario, registry_client, registration_client)
     assert output['y'].data == 45


### PR DESCRIPTION
RegistryClient did two things: 1) manage a replica of the registry and allow clients to register callbacks when there were changes, and 2) talk to a registry REST API via requests and the replication system's REST helpers. This PR splits off the second part of its functionality into a new RegistryRestClient class. Note that we already had one of those, which was just a typedef for a REST client for the registry's replication REST API. That's been incorporated into the new class.

Overall, this increases the amount of code and it adds some abstraction boilerplate, but it more cleanly separates the concerns. Uncle Bob would be proud.

Note: please don't merge, others need to go first and this needs to be merged into a different branch.