### PR TITLE
Compare replicable objects by value

### DIFF
--- a/proof_of_concept/definitions/policy.py
+++ b/proof_of_concept/definitions/policy.py
@@ -1,8 +1,9 @@
 """Classes for describing and managing policies."""
 from proof_of_concept.definitions.signable import Signable
+from proof_of_concept.util import ComparesByValue
 
 
-class Rule(Signable):
+class Rule(ComparesByValue, Signable):
     """Abstract base class for policy rules."""
     def signing_namespace(self) -> str:
         """Return the namespace whose owner must sign this rule."""

--- a/proof_of_concept/definitions/registry.py
+++ b/proof_of_concept/definitions/registry.py
@@ -4,9 +4,10 @@ from typing import Optional
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from proof_of_concept.definitions.identifier import Identifier
+from proof_of_concept.util import ComparesByValue
 
 
-class RegisteredObject:
+class RegisteredObject(ComparesByValue):
     """Base class for objects in the registry."""
     pass
 

--- a/proof_of_concept/policy/replication.py
+++ b/proof_of_concept/policy/replication.py
@@ -32,6 +32,10 @@ class RuleValidator(ObjectValidator[Rule]):
     def is_valid(self, rule: Rule) -> bool:
         """Return True iff the rule is properly signed."""
         if rule.signing_namespace() != self._namespace:
+            logger.error(
+                    f'Rule {rule} is invalid due to a namespace mismatch,'
+                    f' we got {rule.signing_namespace()} but expected'
+                    f' {self._namespace}')
             return False
         return rule.has_valid_signature(self._key)
 

--- a/proof_of_concept/registry/registry.py
+++ b/proof_of_concept/registry/registry.py
@@ -7,7 +7,7 @@ from proof_of_concept.definitions.interfaces import (
         IAssetStore, IRegistration, IRegistryService, IReplicaUpdate)
 from proof_of_concept.definitions.registry import (
         PartyDescription, RegisteredObject, SiteDescription)
-from proof_of_concept.registry.replication import RegistryStore, RegistryUpdate
+from proof_of_concept.registry.replication import RegistryStore
 from proof_of_concept.replication import ReplicableArchive
 
 

--- a/proof_of_concept/replication.py
+++ b/proof_of_concept/replication.py
@@ -192,6 +192,10 @@ class CanonicalStore(IReplicationService[T]):
                     deleted_after(from_version, rec.deleted) and
                     deleted_before(rec.deleted, to_version))}
 
+        readded_objects = new_objects.intersection(deleted_objects)
+        new_objects -= readded_objects
+        deleted_objects -= readded_objects
+
         valid_until = cur_time + timedelta(seconds=self._max_lag)
         return self.UpdateType(
                 from_version, to_version, valid_until,

--- a/proof_of_concept/util.py
+++ b/proof_of_concept/util.py
@@ -1,0 +1,19 @@
+"""Small generic utilities."""
+from typing import Any
+
+
+class ComparesByValue:
+    """Base class for sort-of value types.
+
+    Python doesn't have copy constructors, so we cannot make true
+    value types, but we can make classes that compare by value. This
+    base class implements that.
+    """
+    def __eq__(self, other: Any) -> bool:
+        """Return whether this object equals the other one."""
+        return type(self) == type(other) and self.__dict__ == other.__dict__
+
+    def __hash__(self) -> int:
+        """Return a hash value for this object."""
+        sorted_items = sorted(self.__dict__.items())
+        return hash((self.__class__.__name__, tuple(sorted_items)))

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,57 @@
+from copy import copy
+
+from proof_of_concept.definitions.identifier import Identifier
+from proof_of_concept.definitions.registry import (
+        PartyDescription, SiteDescription)
+from proof_of_concept.registry.registry import Registry
+
+
+def test_parties_are_values(private_key):
+    # If a party is removed and then reinserted into the registry
+    # with the same properties, then the reinserted version of the
+    # party should be considered the same party, and if a replica
+    # update is requested from a version in which the party was present
+    # to a version in which it is again present, then the party should
+    # not show up in the update at all.
+    registry = Registry()
+    party1_key = private_key.public_key()
+    party1 = PartyDescription(
+            Identifier('party:party1_ns:party1'), party1_key)
+
+    registry.register_party(copy(party1))
+    update1 = registry.get_updates_since(0)
+    assert update1.created == {party1}
+    assert not update1.deleted
+
+    registry.deregister_party(copy(party1.id))
+    registry.register_party(copy(party1))
+    update2 = registry.get_updates_since(update1.to_version)
+    assert not update2.created
+    assert not update2.deleted
+
+
+def test_sites_are_values(private_key):
+    # See test_parties_are_values, but for a site.
+    registry = Registry()
+    party1_key = private_key.public_key()
+    party1 = PartyDescription(
+            Identifier('party:party1_ns:party1'), party1_key)
+    registry.register_party(copy(party1))
+
+    site1 = SiteDescription(
+            Identifier('site:party1_ns:site'),
+            Identifier('party:party1_ns:party1'),
+            Identifier('party:party1_ns:party1'),
+            'https://party1.example.com/mahiru',
+            True, True, 'party1_ns')
+
+    registry.register_site(copy(site1))
+    update1 = registry.get_updates_since(0)
+    assert update1.created == {party1, site1}
+    assert not update1.deleted
+
+    registry.deregister_site(copy(site1.id))
+    registry.register_site(copy(site1))
+    update2 = registry.get_updates_since(update1.to_version)
+    assert not update2.created
+    assert not update2.deleted

--- a/tests/test_rule_replication.py
+++ b/tests/test_rule_replication.py
@@ -1,0 +1,54 @@
+from copy import copy
+
+from proof_of_concept.policy.replication import PolicyStore
+from proof_of_concept.policy.rules import (
+        InAssetCollection, InPartyCollection, MayAccess, ResultOfDataIn,
+        ResultOfComputeIn)
+from proof_of_concept.replication import ReplicableArchive
+from proof_of_concept.definitions.policy import Rule
+
+
+def test_rules_are_values():
+    # If a rule in a policy store is removed and then reinserted, the
+    # reinserted version of the rule should be considered the same
+    # rule, and if a replica update is requested from a version in
+    # which the rule was present to a version in which it is again
+    # present, then the rule should not show up in the update at all.
+
+    # This test runs a small scenario in which a rule is inserted and
+    # deleted and reinserted amidst some other changes, and checks that
+    # it is absent from an update straddling the deletion and
+    # reinsertion.
+    archive = ReplicableArchive[Rule]()
+    policy_store = PolicyStore(archive, 1.0)
+
+    rule1 = InAssetCollection(
+            'asset:party1_ns:data1:ns:s',
+            'asset_collection:party1_ns:collection1')
+    rule2 = InPartyCollection(
+            'party:party2_ns:party2', 'party_collection:party2_ns:collection2')
+    rule3 = MayAccess('site:party3_ns:site3', 'asset:party3_ns:data3:ns:s')
+
+    for rule in (rule1, rule2, rule3):
+        policy_store.insert(copy(rule))
+
+    update1 = policy_store.get_updates_since(0)
+    assert update1.created == {rule1, rule2, rule3}
+
+    for rule in (rule1, rule2):
+        policy_store.delete(copy(rule))
+
+    policy_store.insert(copy(rule1))
+
+    rule4a = ResultOfDataIn(
+            'asset:party4_ns:data4:ns:s', 'asset:party4_ns:compute4:ns:s',
+            'asset_collection:party4_ns:collection4')
+    rule4b = ResultOfComputeIn(
+            'asset:party4_ns:data4:ns:s', 'asset:party4_ns:compute4:ns:s',
+            'asset_collection:party4_ns:collection4')
+    policy_store.insert(copy(rule4a))
+    policy_store.insert(copy(rule4b))
+
+    update2 = policy_store.get_updates_since(update1.to_version)
+    assert update2.deleted == {rule2}
+    assert update2.created == {rule4a, rule4b}


### PR DESCRIPTION
Currently, rules and also registered objects are objects, meaning that you can have for example two rules with exactly the same attributes but a different identity. That doesn't make much sense for rules, nor for sites and parties. (Two different parties with the same name? Two different sites with the same endpoint?)

So this PR modifies the Rule and RegisteredObject classes to compare objects of those classes by their attributes, rather than by their address (which is the default).

This also adds another small change, in that it deduplicates replica updates. Those have a set of objects to remove, and a set of objects to add to the replica to update it from one version to another. Currently, if an object is removed and then re-added to the database in between those two versions, then it ends up in both sets, so it gets transmitted twice and then removed and re-added in the replica as well. That's not wrong, but if we deduplicate the update before sending it then we can save ourselves some trouble. And of course that only works if we compare by value, because the two different versions are different objects in Python.

This does not implement the deduplicate-on-insert mentioned in #85. I decided against it again, because adding an object that already exists is an error, and rather than silently ignoring it I'd rather have the duplicate object in the database where we can see it. We may want to have a separate `overwrite()` operation at some point, but that needs more thought and a sensible use case first.

This closes #85.