### PR TITLE
Issue 88: 3. Add a pilot container

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include README.rst
 include mahiru/rest/schemas.yaml
 include mahiru/rest/site_api.yaml
 include mahiru/rest/registry_api.yaml
+include mahiru/data/*

--- a/docker/assets/pilot.Dockerfile
+++ b/docker/assets/pilot.Dockerfile
@@ -1,0 +1,17 @@
+# Mahiru pilot container image.
+
+# To execute a workflow step, Mahiru use a do-nothing pilot container which
+# starts up first and provides a network namespace to set up the network in,
+# before we start the actual compute asset. This image is the image for that
+# pilot.
+
+# Eventually, this should be a from scratch image with a small C program that
+# just sits and waits for a shutdown signal, but for now we'll do the
+# equivalent using a bash script. We have ubuntu:latest already anyway for
+# the other containers.
+FROM ubuntu:latest
+
+COPY sleep.sh /usr/local/bin/sleep.sh
+RUN chmod +x /usr/local/bin/sleep.sh
+
+CMD ["/usr/local/bin/sleep.sh"]

--- a/docker/assets/sleep.sh
+++ b/docker/assets/sleep.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Catch SIGTERM sent by "docker stop" and shut down cleanly
+function stop_container {
+    stopping=true
+}
+
+trap stop_container SIGTERM
+
+while [ -z ${stopping} ] ; do
+    sleep 1
+done
+

--- a/mahiru/data/.gitignore
+++ b/mahiru/data/.gitignore
@@ -1,0 +1,1 @@
+pilot.tar.gz


### PR DESCRIPTION
This adds a pilot container whose namespace the compute asset container will use. It's not actually used yet, but a future PR will set up the network connections in this pilot container so that it can do it before starting the compute asset.

More stacking here, please don't merge.