### PR TITLE
Issue 88: 4. Add net admin helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ docker_images: base_docker_image registry_docker_image site_docker_image pilot_i
 # faster because the tarball of the first doesn't end up in the build
 # context of the second.
 .PHONY: docker_tars
-docker_tars: docker_images registry_docker_tar site_docker_tar pilot_tar
+docker_tars: docker_images registry_docker_tar site_docker_tar pilot_tar net_admin_helper_tar
 
 
 .PHONY: docker_clean
@@ -20,6 +20,7 @@ docker_clean:
 	docker rmi -f mahiru-registry:latest
 	docker rmi -f mahiru-base:latest
 	docker rmi -f mahiru-pilot:latest
+	docker rmi -f net-admin-helper:latest
 
 
 .PHONY: base_docker_image
@@ -50,6 +51,10 @@ site_docker_tar: site_docker_image
 .PHONY: pilot_tar
 pilot_tar: pilot_image
 	docker save mahiru-pilot:latest | gzip -1 -c >mahiru/data/pilot.tar.gz
+
+.PHONY: net_admin_helper_tar
+net_admin_helper_tar:
+	cd net-admin-helper && ./install.sh
 
 
 .PHONY: assets_clean

--- a/mahiru/data/.gitignore
+++ b/mahiru/data/.gitignore
@@ -1,1 +1,2 @@
+net-admin-helper.tar.gz
 pilot.tar.gz

--- a/net-admin-helper/.gitignore
+++ b/net-admin-helper/.gitignore
@@ -1,0 +1,1 @@
+net-admin-helper

--- a/net-admin-helper/config.h
+++ b/net-admin-helper/config.h
@@ -1,0 +1,22 @@
+#pragma once
+
+/** Paths to helper programs.
+ *
+ * net-admin-helper does not search the PATH for reasons of security, so the
+ * paths to the helper applications need to be configured explicitly (and they
+ * must be installed, obviously). This is done here. The given paths should work
+ * in most cases (Debian, Red Hat, and derivatives).
+ */
+#define IP "/sbin/ip"
+#define WG "/usr/bin/wg"
+
+
+/** Settings for container WireGuard */
+
+// device name prefix, use e.g. your application name
+#define CWG_PREFIX "mahiru"
+
+#define ENABLE_CWG_CREATE
+#define ENABLE_CWG_CONNECT
+#define ENABLE_CWG_DESTROY
+

--- a/net-admin-helper/install.sh
+++ b/net-admin-helper/install.sh
@@ -1,0 +1,11 @@
+if [ -d net-admin-helper ] ; then
+    cd net-admin-helper && git checkout develop && git pull && cd ..
+else
+    git clone -b develop https://github.com/SecConNet/net-admin-helper.git
+fi
+
+cp config.h net-admin-helper/
+cd net-admin-helper
+make docker
+docker save net-admin-helper:latest | gzip -1 -c >../../mahiru/data/net-admin-helper.tar.gz
+


### PR DESCRIPTION
This adds a clone-and-build script that will create a Docker image in a tarball containing net-admin-helper, configured for WireGuard container networking.

This is of course the perfect use case for git submodules, but I decided against them after discovering that they really only work well if you configure your git with some specific settings, and that the default will leave users unfamiliar with submodules very confused.

One more for the stack