### PR TITLE
Issue 88: 7. Add serving of assets to the AssetStore

### DIFF
--- a/mahiru/components/asset_store.py
+++ b/mahiru/components/asset_store.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional
 
 from mahiru.definitions.assets import Asset, ComputeAsset, DataAsset
 from mahiru.definitions.identifier import Identifier
-from mahiru.definitions.interfaces import IAssetStore
+from mahiru.definitions.interfaces import IAssetStore, IDomainAdministrator
 from mahiru.policy.evaluation import PermissionCalculator, PolicyEvaluator
 
 
@@ -19,12 +19,25 @@ class AssetStore(IAssetStore):
     """A simple store for assets."""
     def __init__(
             self, policy_evaluator: PolicyEvaluator,
+            domain_administrator: IDomainAdministrator,
             image_dir: Optional[Path] = None) -> None:
-        """Create a new empty AssetStore."""
+        """Create a new empty AssetStore.
+
+        Args:
+            policy_evaluator: Policy evaluator to use for access
+                    checks.
+            domain_administrator: Domain administrator to use for
+                    serving assets over the network.
+            image_dir: Local directory to store image files in.
+        """
         self._policy_evaluator = policy_evaluator
+        self._domain_administrator = domain_administrator
         self._permission_calculator = PermissionCalculator(policy_evaluator)
+
+        # TODO: lock this
         self._assets = dict()  # type: Dict[Identifier, Asset]
         if image_dir is None:
+            # TODO: add mahiru prefix
             image_dir = Path(mkdtemp())
         self._image_dir = image_dir
 

--- a/mahiru/components/ddm_site.py
+++ b/mahiru/components/ddm_site.py
@@ -68,7 +68,8 @@ class Site:
         self._domain_administrator = PlainDockerDA(
                 self._network_administrator, self._site_rest_client)
 
-        self.store = AssetStore(self._policy_evaluator)
+        self.store = AssetStore(
+                self._policy_evaluator, self._domain_administrator)
 
         self.runner = StepRunner(
                 self.id, self._site_rest_client, self._policy_evaluator,

--- a/mahiru/definitions/interfaces.py
+++ b/mahiru/definitions/interfaces.py
@@ -146,6 +146,41 @@ class IAssetStore:
         """
         raise NotImplementedError()
 
+    def serve(
+            self, asset_id: Identifier, request: ConnectionRequest,
+            requester: Identifier) -> ConnectionInfo:
+        """Serves an asset via a secure network connection.
+
+        Args:
+            asset_id: ID of the asset to serve.
+            request: Connection request describing the desired
+                    connection.
+            requester: The site requesting this connection.
+
+        Return:
+            ConnectionInfo object for the connection.
+
+        Raises:
+            KeyError: If the asset was not found.
+            RuntimeError: If the requester does not have permission to
+                    access this asset, or connections are disabled.
+        """
+        raise NotImplementedError()
+
+    def stop_serving(self, conn_id: str, requester: Identifier) -> None:
+        """Stop serving an asset and close the connection.
+
+        Args:
+            conn_id: Connection id previously returned by serve().
+            requester: The site requesting to stop.
+
+        Raises:
+            KeyError: If the connection was not found.
+            RuntimeError: If the requester does not have permission to
+                    stop this connection.
+        """
+        raise NotImplementedError()
+
 
 class IStepRunner:
     """Interface for services for running steps at a given site."""

--- a/tests/test_asset_store.py
+++ b/tests/test_asset_store.py
@@ -10,7 +10,9 @@ from mahiru.definitions.identifier import Identifier
 
 def test_asset_store_store_retrieve(image_dir, test_image_file) -> None:
     mock_policy_evaluator = MagicMock()
-    store = AssetStore(mock_policy_evaluator, image_dir)
+    mock_domain_administrator = MagicMock()
+    store = AssetStore(
+            mock_policy_evaluator, mock_domain_administrator, image_dir)
 
     asset_id = Identifier('asset:ns:test_asset:ns:site')
     asset = DataAsset(asset_id, None, str(test_image_file))
@@ -26,7 +28,9 @@ def test_asset_store_store_retrieve(image_dir, test_image_file) -> None:
 
 def test_asset_store_store_move(image_dir, test_image_file) -> None:
     mock_policy_evaluator = MagicMock()
-    store = AssetStore(mock_policy_evaluator, image_dir)
+    mock_domain_administrator = MagicMock()
+    store = AssetStore(
+            mock_policy_evaluator, mock_domain_administrator, image_dir)
 
     asset = DataAsset(
             'asset:ns:test_asset:ns:site', None, str(test_image_file))


### PR DESCRIPTION
This adds a reference to the DomainAdministrator to the AssetStore, so that the AssetStore can service requests for connecting to an asset as well as requests for downloading it.

<Usual merge warnings>