### PR TITLE
Issue 88: 10. Add a remote data access scenario

### DIFF
--- a/docs/distributed_scenarios.rst
+++ b/docs/distributed_scenarios.rst
@@ -113,6 +113,10 @@ repository:
 (If you don't have ``make`` installed, this will give an error. ``sudo apt-get
 install make`` should fix that.)
 
+This also builds some helper images that are used by Mahiru internally. These
+end up in `mahiru/data`, from where they are included into the Mahiru Docker
+image, and then Mahiru will load them into Docker after it starts up.
+
 Mahiru runs workflows, and each step in a workflow executes a program or script.
 To allow sending these programs to other sites and running them there, they are
 packaged up into container images as well. The same goes for data sets. Mahiru
@@ -191,9 +195,11 @@ Mahiru without destroying and recreating the VMs can be done with
 
 .. code-block:: bash
 
-  vagrant provision --provision-with mahiru_down registry client1 client2
-  vagrant provision --provision-with mahiru_up registry client1 client2
+  vagrant provision --provision-with mahiru_down registry site1 site2
+  vagrant provision --provision-with mahiru_up registry site1 site2 client1 client2
 
+Note the addition of `client1` and `client2` for the `mahiru_up` run. This will
+install the new version on the clients as well for use by the control scripts.
 
 To destroy the VMs, use (without -f you'll have to confirm the destruction of
 each individual VM):

--- a/scenarios/common/mahiru_up.yml
+++ b/scenarios/common/mahiru_up.yml
@@ -205,7 +205,7 @@
       state: present
       create: yes
       regexp: '^network_settings: .*$'
-      line: 'network_settings: { enabled: False }'
+      line: 'network_settings: { enabled: True, external_ip: {{ hostvars[inventory_hostname].ansible_ssh_host }}, ports: [10000, 11000] }'
 
   - name: Configure loglevel
     lineinfile:

--- a/scenarios/data_access/Vagrantfile
+++ b/scenarios/data_access/Vagrantfile
@@ -1,0 +1,78 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+
+  # Set resources
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 512
+    v.cpus = 1
+  end
+
+  config.vm.provider "libvirt" do |v|
+    v.memory = 512
+    v.cpus = 1
+  end
+
+  # Create VMs
+  config.vm.define "registry" do |registry|
+    registry.vm.box = "generic/ubuntu2004"
+  end
+
+  config.vm.define "site1" do |site1|
+    site1.vm.box = "generic/ubuntu2004"
+  end
+
+  config.vm.define "site2" do |site2|
+    site2.vm.box = "generic/ubuntu2004"
+  end
+
+  config.vm.define "client1" do |client1|
+    client1.vm.box = "generic/ubuntu2004"
+
+    client1.vm.provision "configure_sites", type: "ansible", run: "never" do |ansible|
+      ansible.compatibility_mode = "1.8"
+      ansible.verbose = "v"
+      ansible.playbook = "configure_sites.yml"
+    end
+
+    client1.vm.provision "run_experiment", type: "ansible", run: "never" do |ansible|
+        ansible.compatibility_mode = "1.8"
+        ansible.verbose = "v"
+        ansible.playbook = "run_experiment.yml"
+    end
+  end
+
+  config.vm.define "client2" do |client2|
+    client2.vm.box = "generic/ubuntu2004"
+
+    client2.vm.provision "configure_sites", type: "ansible", run: "never" do |ansible|
+      ansible.compatibility_mode = "1.8"
+      ansible.verbose = "v"
+      ansible.playbook = "configure_sites.yml"
+    end
+  end
+
+  # Common software installation for all VMs
+  config.vm.provision "base", type: "ansible" do |ansible|
+    ansible.compatibility_mode = "1.8"
+    ansible.verbose = "v"
+    ansible.playbook = "../common/base.yml"
+  end
+
+  # Start up sites and registry
+  config.vm.provision "mahiru_up", type: "ansible" do |ansible|
+    ansible.compatibility_mode = "1.8"
+    ansible.verbose = "v"
+    ansible.playbook = "../common/mahiru_up.yml"
+  end
+
+  # Shut down sites and registry
+  config.vm.provision "mahiru_down", type: "ansible", run: "never" do |ansible|
+    ansible.compatibility_mode = "1.8"
+    ansible.verbose = "v"
+    ansible.playbook = "../common/mahiru_down.yml"
+  end
+
+end
+

--- a/scenarios/data_access/client1/init_site.py
+++ b/scenarios/data_access/client1/init_site.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric.rsa import (
+        generate_private_key, RSAPrivateKey, RSAPublicKey)
+from cryptography.hazmat.primitives.serialization import (
+    Encoding, PublicFormat)
+import requests
+
+from mahiru.definitions.assets import ComputeAsset, ComputeMetadata, DataAsset
+from mahiru.definitions.registry import PartyDescription, SiteDescription
+from mahiru.policy.rules import (
+        MayAccess, ResultOfComputeIn, ResultOfDataIn)
+from mahiru.rest.registry_client import RegistrationRestClient
+from mahiru.rest.internal_client import InternalSiteRestClient
+
+
+ASSET_DIR = Path.home() / 'mahiru' / 'assets'
+
+
+def register(public_key: RSAPublicKey) -> None:
+    """Registers the current party and site with the registry."""
+    party_id = 'party:party1_ns:party1'
+    party_desc = PartyDescription(party_id, public_key)
+
+    site_id = 'site:party1_ns:site1'
+    endpoint = 'http://site1'
+    namespace = 'party1_ns'
+    site_desc = SiteDescription(
+            site_id, party_id, party_id, endpoint, True, True, namespace)
+
+    client = RegistrationRestClient("http://registry")
+
+    # Remove stale registrations, if any
+    try:
+        client.deregister_site(site_id)
+    except KeyError:
+        pass
+    try:
+        client.deregister_party(party_id)
+    except KeyError:
+        pass
+
+    client.register_party(party_desc)
+    client.register_site(site_desc)
+
+
+def add_initial_assets(client: InternalSiteRestClient) -> None:
+    output_base = DataAsset(
+            'asset:party1_ns:da.data.output_base:party1_ns:site1', None,
+            f'{ASSET_DIR}/data-asset-base.tar.gz')
+
+    script_metadata = ComputeMetadata({
+            'output0': 'asset:party1_ns:da.data.output_base:party1_ns:site1'})
+
+    script = ComputeAsset(
+            'asset:party1_ns:da.software.script1:party1_ns:site1', None,
+            f'{ASSET_DIR}/compute-asset.tar.gz',
+            script_metadata)
+
+    assets = [output_base, script]
+
+    for asset in assets:
+        client.store_asset(asset)
+
+
+def add_initial_rules(
+        client: InternalSiteRestClient, private_key: RSAPrivateKey) -> None:
+    rules = [
+            MayAccess(
+                'site:party1_ns:site1',
+                'asset:party1_ns:da.data.output_base:party1_ns:site1'),
+            MayAccess(
+                'site:party1_ns:site1',
+                'asset:party1_ns:da.software.script1:party1_ns:site1'),
+            ResultOfDataIn(
+                'asset:party1_ns:da.data.output_base:party1_ns:site1', '*',
+                'asset_collection:party1_ns:da.data.public'),
+            ResultOfDataIn(
+                'asset_collection:party1_ns:da.data.public', '*',
+                'asset_collection:party1_ns:da.data.public'),
+            ResultOfComputeIn(
+                '*', 'asset:party1_ns:da.software.script1:party1_ns:site1',
+                'asset_collection:party1_ns:da.data.results'),
+            MayAccess(
+                '*',
+                'asset_collection:party1_ns:da.data.public'),
+            MayAccess(
+                'site:party1_ns:site1',
+                'asset_collection:party1_ns:da.data.results')
+            ]
+
+    for rule in rules:
+        rule.sign(private_key)
+        client.add_rule(rule)
+
+
+if __name__ == "__main__":
+    private_key = generate_private_key(
+            public_exponent=65537, key_size=2048, backend=default_backend())
+
+    key_pem = private_key.public_key().public_bytes(
+            encoding=Encoding.PEM,
+            format=PublicFormat.SubjectPublicKeyInfo
+            ).decode('ascii')
+
+    print(f'Public key: {key_pem}')
+
+    register(private_key.public_key())
+
+    client = InternalSiteRestClient("site1", "http://site1:1080")
+    add_initial_assets(client)
+    add_initial_rules(client, private_key)

--- a/scenarios/data_access/client1/submit_job.py
+++ b/scenarios/data_access/client1/submit_job.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+from mahiru.definitions.workflows import Job, Workflow, WorkflowStep
+from mahiru.rest.internal_client import InternalSiteRestClient
+
+
+if __name__ == '__main__':
+    # create single-step workflow
+    workflow = Workflow(
+            ['input'], {'result': 'compute.output0'}, [
+                WorkflowStep(
+                    name='compute',
+                    inputs={'input0': 'input'},
+                    outputs={'output0':
+                        'asset:party1_ns:da.data.output_base'
+                        ':party1_ns:site1'},
+                    compute_asset_id=(
+                        'asset:party1_ns:da.software.script1'
+                        ':party1_ns:site1'))
+            ]
+    )
+
+    inputs = {'input': 'asset:party2_ns:da.data.input:party2_ns:site2'}
+
+    # run workflow
+    client = InternalSiteRestClient(
+            'site:party1_ns:site1', 'http://site1:1080')
+    print('Submitting job...')
+    job_id = client.submit_job(Job(workflow, inputs))
+    print(f'Submitted, waiting for result at {job_id}')
+    result = client.get_job_result(job_id)
+
+    print(f'Job complete:')
+    print(f'Job: {result.job}')
+    print(f'Plan: {result.plan}')
+    print(f'Outputs: {result.outputs}')

--- a/scenarios/data_access/client2/init_site.py
+++ b/scenarios/data_access/client2/init_site.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric.rsa import (
+        generate_private_key, RSAPrivateKey, RSAPublicKey)
+import requests
+
+from mahiru.definitions.assets import ComputeAsset, ComputeMetadata, DataAsset
+from mahiru.definitions.registry import PartyDescription, SiteDescription
+from mahiru.policy.rules import MayAccess, ResultOfDataIn
+from mahiru.rest.registry_client import RegistrationRestClient
+from mahiru.rest.internal_client import InternalSiteRestClient
+
+
+ASSET_DIR = Path.home() / 'mahiru' / 'assets'
+
+
+def register(public_key: RSAPublicKey) -> None:
+    """Registers the current party and site with the registry."""
+    party_id = 'party:party2_ns:party2'
+    party_desc = PartyDescription(party_id, public_key)
+
+    site_id = 'site:party2_ns:site2'
+    endpoint = 'http://site2'
+    namespace = 'party2_ns'
+    site_desc = SiteDescription(
+            site_id, party_id, party_id, endpoint, True, True, namespace)
+
+    client = RegistrationRestClient("http://registry")
+
+    # Remove stale registrations, if any
+    try:
+        client.deregister_site(site_id)
+    except KeyError:
+        pass
+    try:
+        client.deregister_party(party_id)
+    except KeyError:
+        pass
+
+    client.register_party(party_desc)
+    client.register_site(site_desc)
+
+
+def add_initial_assets(client: InternalSiteRestClient) -> None:
+    data_asset = DataAsset(
+            'asset:party2_ns:da.data.input:party2_ns:site2', None,
+            f'{ASSET_DIR}/data-asset-input.tar.gz')
+
+    client.store_asset(data_asset)
+
+
+def add_initial_rules(
+        client: InternalSiteRestClient, private_key: RSAPrivateKey) -> None:
+    rules = [
+            MayAccess(
+                '*',
+                'asset:party2_ns:da.data.input:party2_ns:site2'),
+            ResultOfDataIn(
+                'asset:party2_ns:da.data.input:party2_ns:site2',
+                'asset:party1_ns:da.software.script1:party1_ns:site1',
+                'asset_collection:party2_ns:da.data.results'),
+            MayAccess(
+                'site:party2_ns:site2',
+                'asset_collection:party2_ns:da.data.results'),
+            MayAccess(
+                'site:party1_ns:site1',
+                'asset_collection:party2_ns:da.data.results')
+            ]
+
+    for rule in rules:
+        rule.sign(private_key)
+        client.add_rule(rule)
+
+
+if __name__ == "__main__":
+    private_key = generate_private_key(
+            public_exponent=65537, key_size=2048, backend=default_backend())
+
+    register(private_key.public_key())
+
+    client = InternalSiteRestClient("site2", "http://site2:1080")
+    add_initial_assets(client)
+    add_initial_rules(client, private_key)

--- a/scenarios/data_access/configure_sites.yml
+++ b/scenarios/data_access/configure_sites.yml
@@ -1,0 +1,72 @@
+# Playbook for configuring client1
+
+- name: Set up client1 VM
+  hosts: client1
+  vars:
+    home: "{{ ansible_facts['user_dir'] }}"
+    asset_dir: "{{ home }}/mahiru/assets"
+    script_dir: "{{ home }}/mahiru/scripts"
+
+  tasks:
+  - name: Create assets directory
+    file:
+      path: "{{ asset_dir }}"
+      state: directory
+
+  - name: Copy assets
+    synchronize:
+      src: "../../build/{{ item }}"
+      dest: "{{ asset_dir }}/{{ item }}"
+    loop:
+      - data-asset-base.tar.gz
+      - compute-asset.tar.gz
+
+  - name: Create script directory
+    file:
+      path: "{{ script_dir }}"
+      state: directory
+
+  - name: Copy scripts
+    synchronize:
+      src: "client1/{{ item }}"
+      dest: "{{ script_dir }}/{{ item }}"
+    loop:
+      - init_site.py
+      - submit_job.py
+
+  - name: Initialise local site
+    command:
+      cmd: "python3 {{ script_dir }}/init_site.py"
+
+
+- name: Set up client2 VM
+  hosts: client2
+  vars:
+    home: "{{ ansible_facts['user_dir'] }}"
+    asset_dir: "{{ home }}/mahiru/assets"
+    script_dir: "{{ home }}/mahiru/scripts"
+
+  tasks:
+  - name: Create assets dir
+    file:
+      path: "{{ asset_dir }}"
+      state: directory
+
+  - name: Copy assets
+    synchronize:
+      src: ../../build/data-asset-input.tar.gz
+      dest: "{{ asset_dir }}/data-asset-input.tar.gz"
+
+  - name: Create script directory
+    file:
+      path: "{{ script_dir }}"
+      state: directory
+
+  - name: Copy init script
+    synchronize:
+      src: client2/init_site.py
+      dest: "{{ script_dir }}/init_site.py"
+
+  - name: Initialise local site
+    command:
+      cmd: "python3 {{ script_dir }}/init_site.py"

--- a/scenarios/data_access/run_experiment.yml
+++ b/scenarios/data_access/run_experiment.yml
@@ -1,0 +1,12 @@
+# Playbook for running the experiment
+
+- name: Run compute-to-data job
+  hosts: client1
+  vars:
+    home: "{{ ansible_facts['user_dir'] }}"
+    script_dir: "{{ home }}/mahiru/scripts"
+
+  tasks:
+  - name: Run job
+    command:
+      cmd: "python3 {{ script_dir }}/submit_job.py"


### PR DESCRIPTION
This adds a new scenario to the test/demo scenarios which demonstrates remote asset access. It actually runs the exact same workflow as the compute-to-data scenario, but the policies are set differently: the compute is not allowed to move, and the data is. Thus, the planner will set up a data-to-compute scenario, and the system will try to connect to the asset remotely. This is enabled in this case, so it succeeds.

This has a fair amount of copy-paste from the compute-to-data version, but I think it's nice if people can look at one scenario at at time without having to jump around to shared code in other directories. I'd like your opinion on that though.

#include <merge_warning.h>