### PR TITLE
Issue 109: Namespaces owned by parties - part 2

### DIFF
--- a/mahiru/components/policy_client.py
+++ b/mahiru/components/policy_client.py
@@ -50,15 +50,16 @@ class PolicyClient(IPolicyCollection):
             deleted: Set of removed objects.
         """
         for o in deleted:
-            if isinstance(o, SiteDescription) and o.namespace:
+            if isinstance(o, SiteDescription) and o.policies:
                 del(self._policy_replicas[o.id])
 
         for o in created:
-            if isinstance(o, SiteDescription) and o.namespace:
+            if isinstance(o, SiteDescription) and o.policies:
                 client = PolicyRestClient(o.endpoint + '/rules/updates')
 
-                key = self._registry_client.get_public_key(o.owner_id)
-                validator = RuleValidator(o.namespace, key)
+                namespace, key = self._registry_client.get_ns_and_key(
+                        o.owner_id)
+                validator = RuleValidator(namespace, key)
                 self._policy_replicas[o.id] = Replica[Rule](
                         client, validator)
 

--- a/mahiru/components/policy_client.py
+++ b/mahiru/components/policy_client.py
@@ -50,11 +50,11 @@ class PolicyClient(IPolicyCollection):
             deleted: Set of removed objects.
         """
         for o in deleted:
-            if isinstance(o, SiteDescription) and o.policies:
+            if isinstance(o, SiteDescription) and o.has_policies:
                 del(self._policy_replicas[o.id])
 
         for o in created:
-            if isinstance(o, SiteDescription) and o.policies:
+            if isinstance(o, SiteDescription) and o.has_policies:
                 client = PolicyRestClient(o.endpoint + '/rules/updates')
 
                 namespace, key = self._registry_client.get_ns_and_key(

--- a/mahiru/components/registry_client.py
+++ b/mahiru/components/registry_client.py
@@ -84,7 +84,7 @@ class RegistryClient:
         sites = list()
         for o in self._registry_replica.objects:
             if isinstance(o, SiteDescription):
-                if o.runner:
+                if o.has_runner:
                     sites.append(o.id)
         return sites
 

--- a/mahiru/components/registry_client.py
+++ b/mahiru/components/registry_client.py
@@ -1,6 +1,6 @@
 """Functionality for connecting to the central registry."""
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Set
+from typing import Any, Callable, List, Optional, Set, Tuple
 
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
@@ -69,14 +69,14 @@ class RegistryClient:
         """
         self._registry_replica.update()
 
-    def get_public_key(self, party_id: Identifier) -> RSAPublicKey:
-        """Get the public key of a party."""
+    def get_ns_and_key(self, party_id: Identifier) -> Tuple[str, RSAPublicKey]:
+        """Get the namespace and public key of a party."""
         # Do not update here, when this is called we're processing one
         # already.
         party = self._get_party(party_id)
         if party is None:
             raise RuntimeError(f'Party with id {party_id} not found')
-        return party.public_key
+        return party.namespace, party.public_key
 
     def list_sites_with_runners(self) -> List[Identifier]:
         """Returns a list of id's of sites with runners."""

--- a/mahiru/definitions/registry.py
+++ b/mahiru/definitions/registry.py
@@ -48,9 +48,9 @@ class SiteDescription(RegisteredObject):
         owner_id: The party which owns this site.
         admin_id: The party which administrates this site.
         endpoint: This site's REST endpoint.
-        runner: Whether the site has a runner.
-        store: Whether the site has a store.
-        policies: Whether the site serves policies.
+        has_runner: Whether the site has a runner.
+        has_store: Whether the site has a store.
+        has_policies: Whether the site serves policies.
     """
     def __init__(
             self,
@@ -58,9 +58,9 @@ class SiteDescription(RegisteredObject):
             owner_id: Identifier,
             admin_id: Identifier,
             endpoint: str,
-            runner: bool,
-            store: bool,
-            policies: bool
+            has_runner: bool,
+            has_store: bool,
+            has_policies: bool
             ) -> None:
         """Create a SiteDescription.
 
@@ -70,19 +70,19 @@ class SiteDescription(RegisteredObject):
             admin_id: Identifier of the party which administrates this
                 site.
             endpoint: URL of the REST endpoint of this site.
-            runner: Whether the site has a runner.
-            store: Whether the site has a store.
-            policies: Whether the site serves policies.
+            has_runner: Whether the site has a runner.
+            has_store: Whether the site has a store.
+            has_policies: Whether the site serves policies.
         """
         self.id = site_id
         self.owner_id = owner_id
         self.admin_id = admin_id
         self.endpoint = endpoint
-        self.runner = runner
-        self.store = store
-        self.policies = policies
+        self.has_runner = has_runner
+        self.has_store = has_store
+        self.has_policies = has_policies
 
-        if runner and not store:
+        if has_runner and not has_store:
             raise RuntimeError('Site with runner needs a store')
 
     def __repr__(self) -> str:

--- a/mahiru/definitions/registry.py
+++ b/mahiru/definitions/registry.py
@@ -50,9 +50,7 @@ class SiteDescription(RegisteredObject):
         endpoint: This site's REST endpoint.
         runner: Whether the site has a runner.
         store: Whether the site has a store.
-        namespace: The namespace managed by this site's policy server,
-            if any.
-
+        policies: Whether the site serves policies.
     """
     def __init__(
             self,
@@ -62,7 +60,7 @@ class SiteDescription(RegisteredObject):
             endpoint: str,
             runner: bool,
             store: bool,
-            namespace: Optional[str]
+            policies: bool
             ) -> None:
         """Create a SiteDescription.
 
@@ -74,9 +72,7 @@ class SiteDescription(RegisteredObject):
             endpoint: URL of the REST endpoint of this site.
             runner: Whether the site has a runner.
             store: Whether the site has a store.
-            namespace: The namespace managed by this site's policy
-                server, if any.
-
+            policies: Whether the site serves policies.
         """
         self.id = site_id
         self.owner_id = owner_id
@@ -84,7 +80,7 @@ class SiteDescription(RegisteredObject):
         self.endpoint = endpoint
         self.runner = runner
         self.store = store
-        self.namespace = namespace
+        self.policies = policies
 
         if runner and not store:
             raise RuntimeError('Site with runner needs a store')

--- a/mahiru/rest/schemas.yaml
+++ b/mahiru/rest/schemas.yaml
@@ -362,9 +362,9 @@ components:
         - owner_id
         - admin_id
         - endpoint
-        - runner
-        - store
-        - policies
+        - has_runner
+        - has_store
+        - has_policies
       properties:
         id:
           description: Identifier of the site
@@ -380,13 +380,13 @@ components:
             REST endpoint at which the site may be contacted.
           type: string
           format: uri
-        runner:
+        has_runner:
           description: Whether the site has a runner
           type: boolean
-        store:
+        has_store:
           description: Whether the site has a store
           type: boolean
-        policies:
+        has_policies:
           description: Whether the site serves policies
           type: boolean
 

--- a/mahiru/rest/schemas.yaml
+++ b/mahiru/rest/schemas.yaml
@@ -364,7 +364,7 @@ components:
         - endpoint
         - runner
         - store
-        - namespace
+        - policies
       properties:
         id:
           description: Identifier of the site
@@ -386,12 +386,9 @@ components:
         store:
           description: Whether the site has a store
           type: boolean
-        namespace:
-          description: >-
-            Namespace for which the policy server serves policy, if there
-            is a policy server at this site, otherwise null.
-          type: string
-          nullable: true
+        policies:
+          description: Whether the site serves policies
+          type: boolean
 
     RegistryUpdate:
       type: object

--- a/mahiru/rest/serialization.py
+++ b/mahiru/rest/serialization.py
@@ -78,7 +78,7 @@ def _serialize_site_description(site_desc: SiteDescription) -> JSON:
     result['endpoint'] = site_desc.endpoint
     result['store'] = site_desc.store
     result['runner'] = site_desc.runner
-    result['namespace'] = site_desc.namespace
+    result['policies'] = site_desc.policies
     return result
 
 
@@ -91,7 +91,7 @@ def _deserialize_site_description(user_input: JSON) -> SiteDescription:
             user_input['endpoint'],
             user_input['store'],
             user_input['runner'],
-            user_input['namespace'])
+            user_input['policies'])
 
 
 def _deserialize_registered_object(user_input: JSON) -> RegisteredObject:

--- a/mahiru/rest/serialization.py
+++ b/mahiru/rest/serialization.py
@@ -76,9 +76,9 @@ def _serialize_site_description(site_desc: SiteDescription) -> JSON:
     result['owner_id'] = site_desc.owner_id
     result['admin_id'] = site_desc.admin_id
     result['endpoint'] = site_desc.endpoint
-    result['store'] = site_desc.store
-    result['runner'] = site_desc.runner
-    result['policies'] = site_desc.policies
+    result['has_store'] = site_desc.has_store
+    result['has_runner'] = site_desc.has_runner
+    result['has_policies'] = site_desc.has_policies
     return result
 
 
@@ -89,9 +89,9 @@ def _deserialize_site_description(user_input: JSON) -> SiteDescription:
             user_input['owner_id'],
             user_input['admin_id'],
             user_input['endpoint'],
-            user_input['store'],
-            user_input['runner'],
-            user_input['policies'])
+            user_input['has_store'],
+            user_input['has_runner'],
+            user_input['has_policies'])
 
 
 def _deserialize_registered_object(user_input: JSON) -> RegisteredObject:

--- a/mahiru/rest/site_client.py
+++ b/mahiru/rest/site_client.py
@@ -34,7 +34,7 @@ class SiteRestClient:
         except KeyError:
             raise RuntimeError(f'Site or store at site {site_id} not found')
 
-        if site.store is not None:
+        if site.has_store:
             safe_asset_id = quote(asset_id, safe='')
             r = requests.get(
                     f'{site.endpoint}/assets/{safe_asset_id}',
@@ -102,7 +102,7 @@ class SiteRestClient:
         except KeyError:
             raise RuntimeError(f'Site or store at site {site_id} not found')
 
-        if site.store is not None:
+        if site.has_store:
             safe_asset_id = quote(asset_id, safe='')
             r = requests.post(
                     f'{site.endpoint}/assets/{safe_asset_id}/connect',
@@ -113,6 +113,8 @@ class SiteRestClient:
             conn_info_json = r.json()
             validate_json('ConnectionInfo', conn_info_json)
             return deserialize(ConnectionInfo, conn_info_json)
+
+        raise RuntimeError(f'Site {site_id} does not have a store')
 
     def disconnect_asset(
             self, asset_id: Identifier, conn_id: str) -> None:
@@ -151,7 +153,7 @@ class SiteRestClient:
         except KeyError:
             raise RuntimeError(f'Site or runner at site {site_id} not found')
 
-        if site.runner:
+        if site.has_runner:
             requests.post(f'{site.endpoint}/jobs', json=serialize(request))
         else:
             raise ValueError(f'Site {site_id} does not have a runner')

--- a/scenarios/compute_to_data/client1/init_site.py
+++ b/scenarios/compute_to_data/client1/init_site.py
@@ -23,13 +23,13 @@ ASSET_DIR = Path.home() / 'mahiru' / 'assets'
 def register(public_key: RSAPublicKey) -> None:
     """Registers the current party and site with the registry."""
     party_id = 'party:party1_ns:party1'
-    party_desc = PartyDescription(party_id, public_key)
+    namespace = 'party1_ns'
+    party_desc = PartyDescription(party_id, namespace, public_key)
 
     site_id = 'site:party1_ns:site1'
     endpoint = 'http://site1'
-    namespace = 'party1_ns'
     site_desc = SiteDescription(
-            site_id, party_id, party_id, endpoint, True, True, namespace)
+            site_id, party_id, party_id, endpoint, True, True, True)
 
     client = RegistrationRestClient("http://registry")
 

--- a/scenarios/compute_to_data/client2/init_site.py
+++ b/scenarios/compute_to_data/client2/init_site.py
@@ -19,13 +19,13 @@ ASSET_DIR = Path.home() / 'mahiru' / 'assets'
 def register(public_key: RSAPublicKey) -> None:
     """Registers the current party and site with the registry."""
     party_id = 'party:party2_ns:party2'
-    party_desc = PartyDescription(party_id, public_key)
+    namespace = 'party2_ns'
+    party_desc = PartyDescription(party_id, namespace, public_key)
 
     site_id = 'site:party2_ns:site2'
     endpoint = 'http://site2'
-    namespace = 'party2_ns'
     site_desc = SiteDescription(
-            site_id, party_id, party_id, endpoint, True, True, namespace)
+            site_id, party_id, party_id, endpoint, True, True, True)
 
     client = RegistrationRestClient("http://registry")
 

--- a/scenarios/data_access/client1/init_site.py
+++ b/scenarios/data_access/client1/init_site.py
@@ -23,13 +23,13 @@ ASSET_DIR = Path.home() / 'mahiru' / 'assets'
 def register(public_key: RSAPublicKey) -> None:
     """Registers the current party and site with the registry."""
     party_id = 'party:party1_ns:party1'
-    party_desc = PartyDescription(party_id, public_key)
+    namespace = 'party1_ns'
+    party_desc = PartyDescription(party_id, namespace, public_key)
 
     site_id = 'site:party1_ns:site1'
     endpoint = 'http://site1'
-    namespace = 'party1_ns'
     site_desc = SiteDescription(
-            site_id, party_id, party_id, endpoint, True, True, namespace)
+            site_id, party_id, party_id, endpoint, True, True, True)
 
     client = RegistrationRestClient("http://registry")
 

--- a/scenarios/data_access/client2/init_site.py
+++ b/scenarios/data_access/client2/init_site.py
@@ -19,13 +19,13 @@ ASSET_DIR = Path.home() / 'mahiru' / 'assets'
 def register(public_key: RSAPublicKey) -> None:
     """Registers the current party and site with the registry."""
     party_id = 'party:party2_ns:party2'
-    party_desc = PartyDescription(party_id, public_key)
+    namespace = 'party2_ns'
+    party_desc = PartyDescription(party_id, namespace, public_key)
 
     site_id = 'site:party2_ns:site2'
     endpoint = 'http://site2'
-    namespace = 'party2_ns'
     site_desc = SiteDescription(
-            site_id, party_id, party_id, endpoint, True, True, namespace)
+            site_id, party_id, party_id, endpoint, True, True, True)
 
     client = RegistrationRestClient("http://registry")
 

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -125,7 +125,7 @@ def run_container_step(
         SiteDescription(
                 site.id, site.owner, site.administrator,
                 site_server.external_endpoint,
-                True, True, site.namespace))
+                True, True, True))
 
     # create single-step workflow
     workflow = Workflow(

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -124,7 +124,7 @@ def register_sites(
                 SiteDescription(
                     site.id, site.owner, site.administrator,
                     servers[site_name].external_endpoint,
-                    True, True, site.namespace))
+                    True, True, True))
 
 
 def stop_servers(servers: Dict[str, SiteServer]):

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
     pydocstyle mahiru
 
 [testenv:docs]
-descriptionn = Build documentation using Sphinx
+description = Build documentation using Sphinx
 deps =
     docutils<0.17
     sphinx


### PR DESCRIPTION
Here's the second part of #109 , now removing the namespaces from the sites. Instead, sites may either serve policies or not, and if they do those policies have to be within the owning party's namespace. This also fixes the scenarios to work with these changes and the ones in part 1.