### PR TITLE
Issue 87: Improve policies - Part 1: outputs

### DIFF
--- a/mahiru/policy/rules.py
+++ b/mahiru/policy/rules.py
@@ -122,6 +122,7 @@ class ResultOfIn(Rule):
             self,
             data_asset: Union[str, Identifier],
             compute_asset: Union[str, Identifier],
+            output: str,
             collection: Union[str, Identifier]
             ) -> None:
         """Create a ResultOfIn rule.
@@ -129,6 +130,8 @@ class ResultOfIn(Rule):
         Args:
             data_asset: The source data asset.
             compute_asset: The compute asset used to process the data.
+            output: The name of the workflow step output that produced
+                    the result Asset, or '*' to match any output.
             collection: The output collection.
         """
         if not isinstance(data_asset, Identifier):
@@ -142,21 +145,23 @@ class ResultOfIn(Rule):
 
         self.data_asset = data_asset
         self.compute_asset = compute_asset
+        self.output = output
         self.collection = collection
 
     def __repr__(self) -> str:
         """Return a string representation of this rule."""
-        return '(result of "{}" on "{}" is in collection "{}")'.format(
-                self.compute_asset, self.data_asset, self.collection)
+        return '(result "{}" of "{}" on "{}" is in collection "{}")'.format(
+                self.output, self.compute_asset, self.data_asset,
+                self.collection)
 
     def signing_representation(self) -> bytes:
         """Return a string of bytes representing the object.
 
         This adapts the Signable base class to this class.
         """
-        return '{}|{}|{}'.format(
-                self.data_asset, self.compute_asset, self.collection
-                ).encode('utf-8')
+        return '{}|{}|{}|{}'.format(
+                self.data_asset, self.compute_asset, self.output,
+                self.collection).encode('utf-8')
 
 
 class ResultOfDataIn(ResultOfIn):

--- a/mahiru/rest/schemas.yaml
+++ b/mahiru/rest/schemas.yaml
@@ -79,6 +79,7 @@ components:
         - signature
         - data_asset
         - compute_asset
+        - output
         - collection
       properties:
         type:
@@ -92,6 +93,9 @@ components:
           type: string
         compute_asset:
           description: Id of the compute asset used to processs it
+          type: string
+        output:
+          description: Name of the output the rule governs.
           type: string
         collection:
           description: Id of the collection the result is in

--- a/mahiru/rest/serialization.py
+++ b/mahiru/rest/serialization.py
@@ -138,6 +138,7 @@ def _serialize_result_of_data_in(rule: ResultOfDataIn) -> JSON:
             'signature': base64.urlsafe_b64encode(rule.signature).decode(),
             'data_asset': rule.data_asset,
             'compute_asset': rule.compute_asset,
+            'output': rule.output,
             'collection': rule.collection}
 
 
@@ -148,6 +149,7 @@ def _serialize_result_of_compute_in(rule: ResultOfComputeIn) -> JSON:
             'signature': base64.urlsafe_b64encode(rule.signature).decode(),
             'data_asset': rule.data_asset,
             'compute_asset': rule.compute_asset,
+            'output': rule.output,
             'collection': rule.collection}
 
 
@@ -163,11 +165,11 @@ def _deserialize_rule(user_input: JSON) -> Rule:
     elif user_input['type'] == 'ResultOfDataIn':
         rule = ResultOfDataIn(
                 user_input['data_asset'], user_input['compute_asset'],
-                user_input['collection'])
+                user_input['output'], user_input['collection'])
     elif user_input['type'] == 'ResultOfComputeIn':
         rule = ResultOfComputeIn(
                 user_input['data_asset'], user_input['compute_asset'],
-                user_input['collection'])
+                user_input['output'], user_input['collection'])
     else:
         raise RuntimeError('Invalid rule type when deserialising')
 

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -87,13 +87,13 @@ def run_container_step(
             MayAccess(
                 'site:ns:test_site', 'asset:ns:output_base:ns:test_site'),
             ResultOfDataIn(
-                'asset:ns:dataset1:ns:test_site', '*',
+                'asset:ns:dataset1:ns:test_site', '*', 'output0',
                 'asset_collection:ns:results1'),
             ResultOfDataIn(
-                'asset:ns:output_base:ns:test_site', '*',
+                'asset:ns:output_base:ns:test_site', '*', '*',
                 'asset_collection:ns:results1'),
             ResultOfComputeIn(
-                '*', 'asset:ns:compute1:ns:test_site',
+                '*', 'asset:ns:compute1:ns:test_site', '*',
                 'asset_collection:ns:public'),
             MayAccess('site:ns:test_site', 'asset_collection:ns:results1'),
             MayAccess('*', 'asset_collection:ns:public')]

--- a/tests/test_rule_replication.py
+++ b/tests/test_rule_replication.py
@@ -42,10 +42,10 @@ def test_rules_are_values():
 
     rule4a = ResultOfDataIn(
             'asset:party4_ns:data4:ns:s', 'asset:party4_ns:compute4:ns:s',
-            'asset_collection:party4_ns:collection4')
+            '*', 'asset_collection:party4_ns:collection4')
     rule4b = ResultOfComputeIn(
             'asset:party4_ns:data4:ns:s', 'asset:party4_ns:compute4:ns:s',
-            'asset_collection:party4_ns:collection4')
+            '*', 'asset_collection:party4_ns:collection4')
     policy_store.insert(copy(rule4a))
     policy_store.insert(copy(rule4b))
 

--- a/tests/test_rule_signatures.py
+++ b/tests/test_rule_signatures.py
@@ -48,7 +48,7 @@ def test_may_access_signatures(private_key):
 def test_result_of_in_signatures(private_key):
     rule = ResultOfDataIn(
             'asset:ns1:dataset.asset1:ns1:site1',
-            'asset:ns1:software.asset2:ns1:site1',
+            'asset:ns1:software.asset2:ns1:site1', 'output0',
             'asset_collection:ns2:collection.collection1')
 
     assert not rule.has_valid_signature(private_key.public_key())
@@ -58,6 +58,11 @@ def test_result_of_in_signatures(private_key):
     rule.data_asset = 'asset:ns2:dataset.test:ns2:site2'
     assert not rule.has_valid_signature(private_key.public_key())
     rule.data_asset = 'asset:ns1:dataset.asset1:ns1:site1'
+    assert rule.has_valid_signature(private_key.public_key())
+
+    rule.output = 'output1'
+    assert not rule.has_valid_signature(private_key.public_key())
+    rule.output = 'output0'
     assert rule.has_valid_signature(private_key.public_key())
 
     rule.collection = 'asset_collection:ns2:collection.coll'

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -200,18 +200,18 @@ def test_pii(registry_server, registry_client, registration_client):
                 'site:party1_ns:site1',
                 'asset_collection:party1_ns:collection.PII1'),
             ResultOfDataIn(
-                'asset_collection:party1_ns:collection.PII1', '*',
+                'asset_collection:party1_ns:collection.PII1', '*', '*',
                 'asset_collection:party1_ns:collection.PII1'),
             ResultOfDataIn(
                 'asset_collection:party1_ns:collection.PII1',
-                'asset:ddm_ns:software.anonymise:ddm_ns:site3',
+                'asset:ddm_ns:software.anonymise:ddm_ns:site3', 'y',
                 'asset_collection:party1_ns:collection.ScienceOnly1'),
             ResultOfDataIn(
                 'asset_collection:party1_ns:collection.PII1',
-                'asset:ddm_ns:software.aggregate:ddm_ns:site3',
+                'asset:ddm_ns:software.aggregate:ddm_ns:site3', 'y',
                 'asset_collection:ddm_ns:collection.Public'),
             ResultOfDataIn(
-                'asset_collection:party1_ns:collection.ScienceOnly1', '*',
+                'asset_collection:party1_ns:collection.ScienceOnly1', '*', '*',
                 'asset_collection:party1_ns:collection.ScienceOnly1'),
             InAssetCollection(
                 'asset_collection:party1_ns:collection.ScienceOnly1',
@@ -229,14 +229,14 @@ def test_pii(registry_server, registry_client, registration_client):
                 'site:party1_ns:site1',
                 'asset_collection:party2_ns:collection.PII2'),
             ResultOfDataIn(
-                'asset_collection:party2_ns:collection.PII2', '*',
+                'asset_collection:party2_ns:collection.PII2', '*', '*',
                 'asset_collection:party2_ns:collection.PII2'),
             ResultOfDataIn(
                 'asset_collection:party2_ns:collection.PII2',
-                'asset:ddm_ns:software.anonymise:ddm_ns:site3',
+                'asset:ddm_ns:software.anonymise:ddm_ns:site3', 'y',
                 'asset_collection:party2_ns:collection.ScienceOnly2'),
             ResultOfDataIn(
-                'asset_collection:party2_ns:collection.ScienceOnly2', '*',
+                'asset_collection:party2_ns:collection.ScienceOnly2', '*', '*',
                 'asset_collection:party2_ns:collection.ScienceOnly2'),
             InAssetCollection(
                 'asset_collection:party2_ns:collection.ScienceOnly2',
@@ -256,19 +256,19 @@ def test_pii(registry_server, registry_client, registration_client):
             MayAccess(
                 '*', 'asset_collection:ddm_ns:collection.PublicSoftware'),
             ResultOfDataIn(
-                'asset_collection:ddm_ns:collection.Public', '*',
+                'asset_collection:ddm_ns:collection.Public', '*', '*',
                 'asset_collection:ddm_ns:collection.Public'),
 
             ResultOfComputeIn(
-                '*', 'asset:ddm_ns:software.anonymise:ddm_ns:site3',
+                '*', 'asset:ddm_ns:software.anonymise:ddm_ns:site3', 'y',
                 'asset_collection:ddm_ns:collection.Public'),
 
             ResultOfComputeIn(
-                '*', 'asset:ddm_ns:software.aggregate:ddm_ns:site3',
+                '*', 'asset:ddm_ns:software.aggregate:ddm_ns:site3', 'y',
                 'asset_collection:ddm_ns:collection.Public'),
 
             ResultOfComputeIn(
-                '*', 'asset:ddm_ns:software.combine:ddm_ns:site3',
+                '*', 'asset:ddm_ns:software.combine:ddm_ns:site3', 'y',
                 'asset_collection:ddm_ns:collection.Public'),
 
             MayAccess(
@@ -366,7 +366,7 @@ def test_saas_with_data(registry_server, registry_client, registration_client):
                 'asset:party1_ns:dataset.data1:party1_ns:site1'),
             ResultOfDataIn(
                 'asset:party1_ns:dataset.data1:party1_ns:site1',
-                'asset:party2_ns:software.addition:party2_ns:site2',
+                'asset:party2_ns:software.addition:party2_ns:site2', 'y',
                 'asset_collection:party1_ns:collection.result1'),
             MayAccess(
                 'site:party1_ns:site1',
@@ -385,15 +385,15 @@ def test_saas_with_data(registry_server, registry_client, registration_client):
                 'asset:party2_ns:software.addition:party2_ns:site2'),
             ResultOfDataIn(
                 'asset:party2_ns:dataset.data2:party2_ns:site2',
-                'asset:party2_ns:software.addition:party2_ns:site2',
+                'asset:party2_ns:software.addition:party2_ns:site2', 'y',
                 'asset_collection:party2_ns:collection.result2'),
             ResultOfComputeIn(
                 'asset:party2_ns:dataset.data2:party2_ns:site2',
-                'asset:party2_ns:software.addition:party2_ns:site2',
+                'asset:party2_ns:software.addition:party2_ns:site2', '*',
                 'asset_collection:party2_ns:collection.result2'),
             ResultOfComputeIn(
                 'asset:party1_ns:dataset.data1:party1_ns:site1',
-                'asset:party2_ns:software.addition:party2_ns:site2',
+                'asset:party2_ns:software.addition:party2_ns:site2', 'y',
                 'asset_collection:party2_ns:collection.result2'),
             MayAccess(
                 'site:party1_ns:site1',

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -30,22 +30,24 @@ def test_wf_output_checks():
             MayAccess('site:ns1:s1', 'asset:ns:Anonymise:ns:s'),
             MayAccess('site:ns1:s1', 'asset:ns:Aggregate:ns:s'),
             ResultOfDataIn(
-                'asset_collection:ns:Public', '*',
+                'asset_collection:ns:Public', '*', '*',
                 'asset_collection:ns:Public'),
             MayAccess('site:ns1:s1', 'asset_collection:ns:Public'),
             MayAccess('site:ns2:s2', 'asset_collection:ns:Public'),
             MayAccess('site:ns1:s1', 'asset:ns1:dataset.d1:ns1:s1'),
             ResultOfDataIn(
-                'asset:ns1:dataset.d1:ns1:s1', 'asset:ns:Anonymise:ns:s',
+                'asset:ns1:dataset.d1:ns1:s1', 'asset:ns:Anonymise:ns:s', 'y',
                 'asset_collection:ns1:Anonymous'),
             ResultOfComputeIn(
-                '*', 'asset:ns:Anonymise:ns:s', 'asset_collection:ns:Public'),
+                '*', 'asset:ns:Anonymise:ns:s', 'y',
+                'asset_collection:ns:Public'),
             MayAccess('site:ns1:s1', 'asset_collection:ns1:Anonymous'),
             ResultOfDataIn(
                 'asset_collection:ns1:Anonymous', 'asset:ns:Aggregate:ns:s',
-                'asset_collection:ns1:Aggregated'),
+                'y', 'asset_collection:ns1:Aggregated'),
             ResultOfComputeIn(
-                '*', 'asset:ns:Aggregate:ns:s', 'asset_collection:ns:Public'),
+                '*', 'asset:ns:Aggregate:ns:s', 'y',
+                'asset_collection:ns:Public'),
             MayAccess('site:ns1:s1', 'asset_collection:ns1:Aggregated'),
             MayAccess('site:ns2:s2', 'asset_collection:ns1:Aggregated'),
             ]


### PR DESCRIPTION
This is the first part of the implementation of policies V2. It adds an `output` attribute to `ResultOfIn` rules, and modifies the evaluation rules so that the rules apply to the specified output. Handy for steps that produce some sensitive and some non-sensitive outputs.

Partially implements #87.