### PR TITLE
Issue 87: Improve policies - Part 2: Asset categories

### DIFF
--- a/mahiru/definitions/identifier.py
+++ b/mahiru/definitions/identifier.py
@@ -13,7 +13,8 @@ class Identifier(str):
     3. site:<namespace>:<name>
     4. asset:<namespace>:<name>:<site_namespace>:<site_name>
     5. asset_collection:<namespace>:<name>
-    6. result:<id_hash>
+    6. asset_category:<namespace>:<name>
+    7. result:<id_hash>
 
     This class also accepts a single asterisk as an identifier, as it
     is used as a wildcard in rules.
@@ -101,10 +102,10 @@ class Identifier(str):
 
     _kinds = (
         'party', 'party_collection', 'site', 'asset', 'asset_collection',
-        'result')
+        'asset_category', 'result')
 
     _lengths = {
             'party': 3, 'party_collection': 3, 'site': 3, 'asset': 5,
-            'asset_collection': 3, 'result': 2}
+            'asset_collection': 3, 'asset_category': 3, 'result': 2}
 
     _segment_regex = re.compile('[a-zA-Z0-9_.-]*')

--- a/mahiru/policy/rules.py
+++ b/mahiru/policy/rules.py
@@ -44,6 +44,41 @@ class InAssetCollection(Rule):
         return self.asset.namespace()
 
 
+class InAssetCategory(Rule):
+    """Says that an AssetCategory contains an Asset."""
+    def __init__(
+            self, asset: Union[str, Identifier],
+            category: Union[str, Identifier]
+            ) -> None:
+        """Create an InAssetCategory rule.
+
+        Args:
+            asset: The asset to add to the category.
+            category: The category to add it to.
+        """
+        if not isinstance(asset, Identifier):
+            asset = Identifier(asset)
+        self.asset = asset
+        if not isinstance(category, Identifier):
+            category = Identifier(category)
+        self.category = category
+
+    def __repr__(self) -> str:
+        """Return a string representation of this rule."""
+        return '("{}" is in "{}")'.format(self.asset, self.category)
+
+    def signing_representation(self) -> bytes:
+        """Return a string of bytes representing the object.
+
+        This adapts the Signable base class to this class.
+        """
+        return '{}|{}'.format(self.asset, self.category).encode('utf-8')
+
+    def signing_namespace(self) -> str:
+        """Return the namespace whose owner must sign this rule."""
+        return self.category.namespace()
+
+
 class InPartyCollection(Rule):
     """Says that Party party is in PartyCollection collection."""
     def __init__(

--- a/mahiru/rest/serialization.py
+++ b/mahiru/rest/serialization.py
@@ -24,8 +24,8 @@ from mahiru.definitions.workflows import (
 
 from mahiru.policy.definitions import PolicyUpdate
 from mahiru.policy.rules import (
-        InAssetCollection, InPartyCollection, MayAccess, ResultOfComputeIn,
-        ResultOfDataIn)
+        InAssetCollection, InAssetCategory, InPartyCollection, MayAccess,
+        ResultOfComputeIn, ResultOfDataIn)
 
 from mahiru.registry.replication import RegistryUpdate
 from mahiru.replication import ReplicaUpdate
@@ -113,6 +113,15 @@ def _serialize_in_asset_collection(rule: InAssetCollection) -> JSON:
             'collection': rule.collection}
 
 
+def _serialize_in_asset_category(rule: InAssetCategory) -> JSON:
+    """Serialize an InAssetCategory object to JSON."""
+    return {
+            'type': 'InAssetCategory',
+            'signature': base64.urlsafe_b64encode(rule.signature).decode(),
+            'asset': rule.asset,
+            'category': rule.category}
+
+
 def _serialize_in_party_collection(rule: InPartyCollection) -> JSON:
     """Serialize an InPartyCollection object to JSON."""
     return {
@@ -158,6 +167,8 @@ def _deserialize_rule(user_input: JSON) -> Rule:
     rule = None     # type: Optional[Rule]
     if user_input['type'] == 'InAssetCollection':
         rule = InAssetCollection(user_input['asset'], user_input['collection'])
+    elif user_input['type'] == 'InAssetCategory':
+        rule = InAssetCategory(user_input['asset'], user_input['category'])
     elif user_input['type'] == 'InPartyCollection':
         rule = InPartyCollection(user_input['party'], user_input['collection'])
     elif user_input['type'] == 'MayAccess':
@@ -434,6 +445,7 @@ _serializers = {
         PartyDescription: _serialize_party_description,
         SiteDescription: _serialize_site_description,
         InAssetCollection: _serialize_in_asset_collection,
+        InAssetCategory: _serialize_in_asset_category,
         InPartyCollection: _serialize_in_party_collection,
         MayAccess: _serialize_may_access,
         ResultOfDataIn: _serialize_result_of_data_in,

--- a/tests/test_policy_evaluation.py
+++ b/tests/test_policy_evaluation.py
@@ -1,0 +1,417 @@
+from typing import Iterable, List
+
+import pytest
+
+from mahiru.definitions.identifier import Identifier
+from mahiru.definitions.interfaces import IPolicyCollection
+from mahiru.policy.evaluation import Permissions, PolicyEvaluator
+from mahiru.policy.rules import (
+        InAssetCategory, InAssetCollection, MayAccess, ResultOfComputeIn,
+        ResultOfDataIn, Rule)
+
+
+@pytest.fixture
+def any_asset() -> Identifier:
+    """Return a wildcard identifier."""
+    return Identifier('*')
+
+
+@pytest.fixture
+def asset1() -> Identifier:
+    """Identifier for an asset owned by party1."""
+    return Identifier('asset:ns1:asset1:ns1:site1')
+
+
+@pytest.fixture
+def asset2() -> Identifier:
+    """Identifier for an asset owned by party2."""
+    return Identifier('asset:ns2:asset2:ns2:site2')
+
+
+@pytest.fixture
+def asset3() -> Identifier:
+    """Identifier for an asset owned by party3."""
+    return Identifier('asset:ns3:asset3:ns3:site3')
+
+
+@pytest.fixture
+def site1() -> Identifier:
+    """Identifier for a site owned by party1."""
+    return Identifier('site:ns1:site1')
+
+
+@pytest.fixture
+def site2() -> Identifier:
+    """Identifier for a site owned by party2."""
+    return Identifier('site:ns2:site2')
+
+
+@pytest.fixture
+def asset_collection1a() -> Identifier:
+    """Identifier for an asset collection owned by party1."""
+    return Identifier('asset_collection:ns1:asset_collection_a')
+
+
+@pytest.fixture
+def asset_collection1b() -> Identifier:
+    """Identifier for an asset collection owned by party1."""
+    return Identifier('asset_collection:ns1:asset_collection_b')
+
+
+@pytest.fixture
+def asset_collection1c() -> Identifier:
+    """Identifier for an asset collection owned by party1."""
+    return Identifier('asset_collection:ns1:asset_collection_c')
+
+
+@pytest.fixture
+def asset_collection2a() -> Identifier:
+    """Identifier for an asset collection owned by party2."""
+    return Identifier('asset_collection:ns2:asset_collection_a')
+
+
+@pytest.fixture
+def asset_collection2b() -> Identifier:
+    """Identifier for an asset collection owned by party2."""
+    return Identifier('asset_collection:ns2:asset_collection_b')
+
+
+@pytest.fixture
+def asset_collection3a() -> Identifier:
+    """Identifier for an asset collection owned by party3."""
+    return Identifier('asset_collection:ns3:asset_collection_a')
+
+
+@pytest.fixture
+def asset_category1a() -> Identifier:
+    """Identifier for an asset category owned by party1."""
+    return Identifier('asset_category:ns1:asset_category_a')
+
+
+@pytest.fixture
+def asset_category1b() -> Identifier:
+    """Identifier for an asset category owned by party1."""
+    return Identifier('asset_category:ns1:asset_category_b')
+
+
+@pytest.fixture
+def asset_category2a() -> Identifier:
+    """Identifier for an asset category owned by party2."""
+    return Identifier('asset_category:ns2:asset_category_a')
+
+
+@pytest.fixture
+def asset_category2b() -> Identifier:
+    """Identifier for an asset category owned by party2."""
+    return Identifier('asset_category:ns2:asset_category_b')
+
+
+@pytest.fixture
+def asset_category3a() -> Identifier:
+    """Identifier for an asset category owned by party3."""
+    return Identifier('asset_category:ns3:asset_category_a')
+
+
+class MockPolicies(IPolicyCollection):
+    def __init__(self, policies: List[Rule]) -> None:
+        self._policies = policies
+
+    def policies(self) -> Iterable[Rule]:
+        return self._policies
+
+
+# MayAccess tests
+
+
+def test_primary_asset_access(asset1, site1, site2):
+    policies = MockPolicies([MayAccess(site1, asset1)])
+    evaluator = PolicyEvaluator(policies)
+
+    perms = evaluator.permissions_for_asset(asset1)
+    assert perms._sets == [{asset1}]
+    assert evaluator.may_access(perms, site1)
+    assert not evaluator.may_access(perms, site2)
+
+
+def test_asset_collection_access(asset1, asset_collection1a, site1, site2):
+    policies = MockPolicies([
+        InAssetCollection(asset1, asset_collection1a),
+        MayAccess(site1, asset_collection1a)])
+    evaluator = PolicyEvaluator(policies)
+
+    perms = evaluator.permissions_for_asset(asset1)
+    assert perms._sets == [{asset1, asset_collection1a}]
+    assert evaluator.may_access(perms, site1)
+    assert not evaluator.may_access(perms, site2)
+
+
+def test_asset_category_access(asset1, asset_category1a, site1):
+    policies = MockPolicies([
+        InAssetCategory(asset1, asset_category1a),
+        MayAccess(site1, asset_category1a)])
+    evaluator = PolicyEvaluator(policies)
+
+    perms = evaluator.permissions_for_asset(asset1)
+    assert perms._sets == [{asset1}]
+    assert not evaluator.may_access(perms, site1)
+
+
+# Propagation tests
+
+
+def test_propagate_result_of_data_in(asset1, asset2, asset_collection1a):
+    policies = MockPolicies([
+        ResultOfDataIn(asset1, asset2, 'output1', asset_collection1a)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset1}])]
+    perms = evaluator.propagate_permissions(input_perms, asset2, 'output1')
+    assert perms._sets == [{asset_collection1a}, set()]
+
+
+def test_propagate_result_of_data_in_data_collection(
+        asset1, asset2, asset_collection1a, asset_collection1b):
+    policies = MockPolicies([
+        InAssetCollection(asset1, asset_collection1a),
+        ResultOfDataIn(
+            asset_collection1a, asset2, 'output1', asset_collection1b)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset1}])]
+    perms = evaluator.propagate_permissions(input_perms, asset2, 'output1')
+    assert perms._sets == [{asset_collection1b}, set()]
+
+
+def test_propagate_result_of_data_in_data_category(
+        asset1, asset2, asset_category1a, asset_collection1a):
+    policies = MockPolicies([
+        InAssetCategory(asset1, asset_category1a),
+        ResultOfDataIn(
+            asset_category1a, asset2, 'output1', asset_collection1a)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset1}])]
+    perms = evaluator.propagate_permissions(input_perms, asset2, 'output1')
+    assert perms._sets == [set(), set()]
+
+
+def test_propagate_result_of_data_in_compute_collection(
+        asset1, asset2, asset_collection1a, asset_collection1b):
+    policies = MockPolicies([
+        InAssetCollection(asset1, asset_collection1a),
+        ResultOfDataIn(
+            asset2, asset_collection1a, 'output1', asset_collection1b)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset2}])]
+    perms = evaluator.propagate_permissions(input_perms, asset2, 'output1')
+    assert perms._sets == [set(), set()]
+
+
+def test_propagate_result_of_data_in_compute_category(
+        asset1, asset2, asset_collection1a, asset_category1a):
+    policies = MockPolicies([
+        InAssetCategory(asset1, asset_category1a),
+        ResultOfDataIn(
+            asset2, asset_category1a, 'output1', asset_collection1a)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset2}])]
+    perms = evaluator.propagate_permissions(input_perms, asset1, 'output1')
+    assert perms._sets == [{asset_collection1a}, set()]
+
+
+def test_propagate_result_of_compute_in(asset1, asset2, asset_collection2a):
+    policies = MockPolicies([
+        ResultOfComputeIn(asset1, asset2, 'output1', asset_collection2a)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset1}])]
+    perms = evaluator.propagate_permissions(input_perms, asset2, 'output1')
+    assert perms._sets == [set(), {asset_collection2a}]
+
+
+def test_propagate_result_of_compute_in_data_collection(
+        asset1, asset2, asset_collection1a, asset_collection2a):
+    policies = MockPolicies([
+        InAssetCollection(asset1, asset_collection1a),
+        ResultOfComputeIn(
+            asset_collection1a, asset2, 'output1', asset_collection2a)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset1}])]
+    perms = evaluator.propagate_permissions(input_perms, asset2, 'output1')
+    assert perms._sets == [set(), set()]
+
+
+def test_propagate_result_of_compute_in_data_category(
+        asset1, asset2, asset_category2a, asset_collection2a):
+    policies = MockPolicies([
+        InAssetCategory(asset1, asset_category2a),
+        ResultOfComputeIn(
+            asset_category2a, asset2, 'output1', asset_collection2a)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset1}])]
+    perms = evaluator.propagate_permissions(input_perms, asset2, 'output1')
+    assert perms._sets == [set(), {asset_collection2a}]
+
+
+def test_propagate_result_of_compute_in_compute_collection(
+        asset1, asset2, asset_collection1a, asset_collection1b):
+    policies = MockPolicies([
+        InAssetCollection(asset1, asset_collection1a),
+        ResultOfComputeIn(
+            asset2, asset_collection1a, 'output1', asset_collection1b)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset2}])]
+    perms = evaluator.propagate_permissions(input_perms, asset1, 'output1')
+    assert perms._sets == [set(), {asset_collection1b}]
+
+
+def test_propagate_result_of_compute_in_compute_category(
+        asset1, asset2, asset_collection1a, asset_category1a):
+    policies = MockPolicies([
+        InAssetCategory(asset1, asset_category1a),
+        ResultOfComputeIn(
+            asset2, asset_category1a, 'output1', asset_collection1a)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset2}])]
+    perms = evaluator.propagate_permissions(input_perms, asset1, 'output1')
+    assert perms._sets == [set(), set()]
+
+
+def test_propagate_result_of_data_in_deep1(
+        asset1, asset_collection1a, asset_collection1b,
+        asset2, asset_category1a, asset_category1b,
+        asset_collection1c):
+
+    policies = MockPolicies([
+        InAssetCollection(asset1, asset_collection1a),
+        InAssetCollection(asset_collection1a, asset_collection1b),
+        InAssetCategory(asset2, asset_category1a),
+        InAssetCategory(asset_category1a, asset_category1b),
+        ResultOfDataIn(
+            asset_collection1b, asset_category1b, 'output1',
+            asset_collection1c)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset1}])]
+    perms = evaluator.propagate_permissions(input_perms, asset2, 'output1')
+    assert perms._sets == [{asset_collection1c}, set()]
+
+
+def test_propagate_result_of_data_in_deep2(
+        asset1, asset_collection1a, asset_collection1b,
+        asset2, asset_collection1c):
+
+    policies = MockPolicies([
+        InAssetCollection(asset1, asset_collection1a),
+        InAssetCollection(asset_collection1b, asset_collection1a),
+        ResultOfDataIn(
+            asset_collection1b, asset2, 'output1', asset_collection1c)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset1}])]
+    perms = evaluator.propagate_permissions(input_perms, asset2, 'output1')
+    assert perms._sets == [set(), set()]
+
+
+def test_propagate_result_of_data_in_deep3(
+        asset1, asset2, asset_category1a, asset_category1b,
+        asset_collection1c):
+
+    policies = MockPolicies([
+        InAssetCategory(asset2, asset_category1a),
+        InAssetCategory(asset_category1b, asset_category1a),
+        ResultOfDataIn(
+            asset1, asset_category1b, 'output1', asset_collection1c)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset1}])]
+    perms = evaluator.propagate_permissions(input_perms, asset2, 'output1')
+    assert perms._sets == [set(), set()]
+
+
+def test_propagate_result_of_compute_in_deep1(
+        asset1, asset_collection1a, asset_collection1b,
+        asset2, asset_category1a, asset_category1b,
+        asset_collection1c):
+
+    policies = MockPolicies([
+        InAssetCollection(asset1, asset_collection1a),
+        InAssetCollection(asset_collection1a, asset_collection1b),
+        InAssetCategory(asset2, asset_category1a),
+        InAssetCategory(asset_category1a, asset_category1b),
+        ResultOfComputeIn(
+            asset_category1b, asset_collection1b, 'output1',
+            asset_collection1c)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset2}])]
+    perms = evaluator.propagate_permissions(input_perms, asset1, 'output1')
+    assert perms._sets == [set(), {asset_collection1c}]
+
+
+def test_propagate_multiple_inputs(
+        asset1, asset2, asset3, asset_collection1a, asset_collection2a,
+        asset_category3a, asset_collection3a):
+
+    policies = MockPolicies([
+        ResultOfDataIn(asset1, asset3, 'output1', asset_collection1a),
+        ResultOfDataIn(asset2, asset3, 'output1', asset_collection2a),
+        InAssetCategory(asset1, asset_category3a),
+        InAssetCategory(asset2, asset_category3a),
+        ResultOfComputeIn(
+            asset_category3a, asset3, 'output1', asset_collection3a)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset1}]), Permissions([{asset2}])]
+    perms = evaluator.propagate_permissions(input_perms, asset3, 'output1')
+    assert perms._sets == [
+        {asset_collection1a}, {asset_collection3a},
+        {asset_collection2a}, {asset_collection3a}]
+
+
+def test_propagate_multiple_outputs(
+        asset1, asset2, asset_collection1a, asset_collection1b,
+        asset_collection2a, asset_collection2b):
+    policies = MockPolicies([
+        ResultOfDataIn(asset1, asset2, 'output1', asset_collection1a),
+        ResultOfDataIn(asset1, asset2, 'output2', asset_collection1b),
+        ResultOfComputeIn(asset1, asset2, 'output1', asset_collection2a),
+        ResultOfComputeIn(asset1, asset2, 'output2', asset_collection2b)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset1}])]
+    perms = evaluator.propagate_permissions(input_perms, asset2, 'output1')
+    assert perms._sets == [{asset_collection1a}, {asset_collection2a}]
+
+    perms = evaluator.propagate_permissions(input_perms, asset2, 'output2')
+    assert perms._sets == [{asset_collection1b}, {asset_collection2b}]
+
+
+def test_propagate_asset_wildcards(
+        asset1, asset2, asset_collection1a, asset_collection2a, any_asset):
+    policies = MockPolicies([
+        ResultOfDataIn(asset1, any_asset, 'output1', asset_collection1a),
+        ResultOfComputeIn(any_asset, asset2, 'output1', asset_collection2a)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset1}])]
+    perms = evaluator.propagate_permissions(input_perms, asset2, 'output1')
+    assert perms._sets == [{asset_collection1a}, {asset_collection2a}]
+
+
+def test_propagate_output_wildcards(
+        asset1, asset2, asset_collection1a, asset_collection2a):
+    policies = MockPolicies([
+        ResultOfDataIn(asset1, asset2, '*', asset_collection1a),
+        ResultOfComputeIn(asset1, asset2, '*', asset_collection2a)])
+    evaluator = PolicyEvaluator(policies)
+
+    input_perms = [Permissions([{asset1}])]
+    perms = evaluator.propagate_permissions(input_perms, asset2, 'output1')
+    assert perms._sets == [{asset_collection1a}, {asset_collection2a}]

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
 
 commands =
     mypy
-    pytest
+    pytest {posargs}
     pycodestyle mahiru tests
     pydocstyle mahiru
 


### PR DESCRIPTION
This adds the `InAssetCategory` rule for putting assets into categories, modifies the policy evaluation algorithm to use them where appropriate, and adds a bunch of unit tests for policies.

The unit tests are a bit repetitive, I've tried to simplify them but it doesn't get much better. But it's a bunch of tests, some repetition is okay.