### PR TITLE
Issue 87: Improve policies - Part 3: Add site categories

### DIFF
--- a/mahiru/definitions/identifier.py
+++ b/mahiru/definitions/identifier.py
@@ -11,10 +11,11 @@ class Identifier(str):
     1. party:<namespace>:<name>
     2. party_collection:<namespace>:<name>
     3. site:<namespace>:<name>
-    4. asset:<namespace>:<name>:<site_namespace>:<site_name>
-    5. asset_collection:<namespace>:<name>
-    6. asset_category:<namespace>:<name>
-    7. result:<id_hash>
+    4. site_category:<namespace>:<name>
+    5. asset:<namespace>:<name>:<site_namespace>:<site_name>
+    6. asset_collection:<namespace>:<name>
+    7. asset_category:<namespace>:<name>
+    8. result:<id_hash>
 
     This class also accepts a single asterisk as an identifier, as it
     is used as a wildcard in rules.
@@ -101,11 +102,12 @@ class Identifier(str):
         return Identifier(f'site:{self.segments[3]}:{self.segments[4]}')
 
     _kinds = (
-        'party', 'party_collection', 'site', 'asset', 'asset_collection',
-        'asset_category', 'result')
+        'party', 'party_collection', 'site', 'site_category', 'asset',
+        'asset_collection', 'asset_category', 'result')
 
     _lengths = {
-            'party': 3, 'party_collection': 3, 'site': 3, 'asset': 5,
-            'asset_collection': 3, 'asset_category': 3, 'result': 2}
+            'party': 3, 'party_collection': 3, 'site': 3, 'site_category': 3,
+            'asset': 5, 'asset_collection': 3, 'asset_category': 3,
+            'result': 2}
 
     _segment_regex = re.compile('[a-zA-Z0-9_.-]*')

--- a/mahiru/definitions/policy.py
+++ b/mahiru/definitions/policy.py
@@ -7,4 +7,4 @@ class Rule(ComparesByValue, Signable):
     """Abstract base class for policy rules."""
     def signing_namespace(self) -> str:
         """Return the namespace whose owner must sign this rule."""
-        raise NotImplemented
+        raise NotImplementedError

--- a/mahiru/policy/rules.py
+++ b/mahiru/policy/rules.py
@@ -5,7 +5,21 @@ from mahiru.definitions.identifier import Identifier
 from mahiru.definitions.policy import Rule
 
 
-class InAssetCollection(Rule):
+class GroupingRule(Rule):
+    """Subclass for rules that represent groupings."""
+    def grouped(self) -> Identifier:
+        """Return the thing being grouped by this rule."""
+        raise NotImplementedError
+
+    def group(self) -> Identifier:
+        """Return the grouping of the rule.
+
+        This returns the collection or category.
+        """
+        raise NotImplementedError
+
+
+class InAssetCollection(GroupingRule):
     """Says that an Asset is in an AssetCollection.
 
     This implies that anyone who can access the collection can access
@@ -32,6 +46,14 @@ class InAssetCollection(Rule):
         """Return a string representation of this rule."""
         return '("{}" is in "{}")'.format(self.asset, self.collection)
 
+    def grouped(self) -> Identifier:
+        """Return the thing being grouped by this rule."""
+        return self.asset
+
+    def group(self) -> Identifier:
+        """Return the grouping of the rule."""
+        return self.collection
+
     def signing_representation(self) -> bytes:
         """Return a string of bytes representing the object.
 
@@ -44,7 +66,7 @@ class InAssetCollection(Rule):
         return self.asset.namespace()
 
 
-class InAssetCategory(Rule):
+class InAssetCategory(GroupingRule):
     """Says that an AssetCategory contains an Asset."""
     def __init__(
             self, asset: Union[str, Identifier],
@@ -62,6 +84,14 @@ class InAssetCategory(Rule):
         if not isinstance(category, Identifier):
             category = Identifier(category)
         self.category = category
+
+    def grouped(self) -> Identifier:
+        """Return the thing being grouped by this rule."""
+        return self.asset
+
+    def group(self) -> Identifier:
+        """Return the grouping of the rule."""
+        return self.category
 
     def __repr__(self) -> str:
         """Return a string representation of this rule."""

--- a/mahiru/policy/rules.py
+++ b/mahiru/policy/rules.py
@@ -144,6 +144,49 @@ class InPartyCollection(Rule):
         return self.collection.namespace()
 
 
+class InSiteCategory(GroupingRule):
+    """Says that a SiteCategory contains an Site."""
+    def __init__(
+            self, site: Union[str, Identifier],
+            category: Union[str, Identifier]
+            ) -> None:
+        """Create an InSiteCategory rule.
+
+        Args:
+            site: The site to add to the category.
+            category: The category to add it to.
+        """
+        if not isinstance(site, Identifier):
+            site = Identifier(site)
+        self.site = site
+        if not isinstance(category, Identifier):
+            category = Identifier(category)
+        self.category = category
+
+    def grouped(self) -> Identifier:
+        """Return the thing being grouped by this rule."""
+        return self.site
+
+    def group(self) -> Identifier:
+        """Return the grouping of the rule."""
+        return self.category
+
+    def __repr__(self) -> str:
+        """Return a string representation of this rule."""
+        return '("{}" is in "{}")'.format(self.site, self.category)
+
+    def signing_representation(self) -> bytes:
+        """Return a string of bytes representing the object.
+
+        This adapts the Signable base class to this class.
+        """
+        return '{}|{}'.format(self.site, self.category).encode('utf-8')
+
+    def signing_namespace(self) -> str:
+        """Return the namespace whose owner must sign this rule."""
+        return self.category.namespace()
+
+
 class MayAccess(Rule):
     """Says that Site site may access Asset asset."""
     def __init__(


### PR DESCRIPTION
This adds the `InSiteCategory` rule, which lets people categorise sites. Put trusted sites into a category and give access to them in one fell MayAccess rule! Or make categories of sites whose owners have paid to be allowed to run your software on their site! Categories make everything easier.