### PR TITLE
Issue 87: Improve policies - Part 3b: Refactor

### DIFF
--- a/mahiru/definitions/identifier.py
+++ b/mahiru/definitions/identifier.py
@@ -9,7 +9,7 @@ class Identifier(str):
     An Identifier is a string of any of the following forms:
 
     1. party:<namespace>:<name>
-    2. party_collection:<namespace>:<name>
+    2. party_category:<namespace>:<name>
     3. site:<namespace>:<name>
     4. site_category:<namespace>:<name>
     5. asset:<namespace>:<name>:<site_namespace>:<site_name>
@@ -102,11 +102,11 @@ class Identifier(str):
         return Identifier(f'site:{self.segments[3]}:{self.segments[4]}')
 
     _kinds = (
-        'party', 'party_collection', 'site', 'site_category', 'asset',
+        'party', 'party_category', 'site', 'site_category', 'asset',
         'asset_collection', 'asset_category', 'result')
 
     _lengths = {
-            'party': 3, 'party_collection': 3, 'site': 3, 'site_category': 3,
+            'party': 3, 'party_category': 3, 'site': 3, 'site_category': 3,
             'asset': 5, 'asset_collection': 3, 'asset_category': 3,
             'result': 2}
 

--- a/mahiru/policy/evaluation.py
+++ b/mahiru/policy/evaluation.py
@@ -5,7 +5,7 @@ from mahiru.definitions.identifier import Identifier
 from mahiru.definitions.interfaces import IPolicyCollection
 from mahiru.definitions.workflows import Job, Plan, Workflow, WorkflowStep
 from mahiru.policy.rules import (
-        GroupingRule, InAssetCategory, InAssetCollection, InPartyCollection,
+        GroupingRule, InAssetCategory, InAssetCollection,
         InSiteCategory, MayAccess, ResultOfIn, ResultOfDataIn,
         ResultOfComputeIn)
 
@@ -112,27 +112,6 @@ class PolicyEvaluator:
         equiv_sites = self._upward_equivalent_objects(InSiteCategory, site)
         return all([matches_one(asset_set, equiv_sites)
                     for asset_set in permissions._sets])
-
-    def _equivalent_parties(self, party: str) -> List[str]:
-        """Returns all the parties whose rules apply to an asset.
-
-        These are the parties itself, and all parties that are party
-        collections that the party is directly or indirectly in.
-
-        Args:
-            party: The party to find equivalents for.
-        """
-        cur_parties = list()     # type: List[str]
-        new_parties = [party]
-        while new_parties:
-            cur_parties.extend(new_parties)
-            new_parties = list()
-            for party in cur_parties:
-                for rule in self._policy_collection.policies():
-                    if isinstance(rule, InPartyCollection):
-                        if rule.party == party:
-                            new_parties.append(rule.collection)
-        return cur_parties
 
     def _upward_equivalent_objects(
             self, rule_type: Type[_GroupingRule], obj: Identifier

--- a/mahiru/policy/replication.py
+++ b/mahiru/policy/replication.py
@@ -3,9 +3,6 @@ import logging
 
 from mahiru.definitions.policy import Rule
 from mahiru.policy.definitions import PolicyUpdate
-from mahiru.policy.rules import (
-        InAssetCollection, InPartyCollection, MayAccess, ResultOfIn,
-        ResultOfDataIn, ResultOfComputeIn)
 from mahiru.replication import CanonicalStore, ObjectValidator
 
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey

--- a/mahiru/policy/rules.py
+++ b/mahiru/policy/rules.py
@@ -110,7 +110,7 @@ class InAssetCategory(GroupingRule):
 
 
 class InPartyCategory(GroupingRule):
-    """Says that a PartyCollection contains a Party."""
+    """Says that a PartyCategory contains a Party."""
     def __init__(
             self, party: Union[str, Identifier],
             category: Union[str, Identifier]

--- a/mahiru/policy/rules.py
+++ b/mahiru/policy/rules.py
@@ -109,39 +109,47 @@ class InAssetCategory(GroupingRule):
         return self.category.namespace()
 
 
-class InPartyCollection(Rule):
-    """Says that Party party is in PartyCollection collection."""
+class InPartyCategory(GroupingRule):
+    """Says that a PartyCollection contains a Party."""
     def __init__(
             self, party: Union[str, Identifier],
-            collection: Union[str, Identifier]
+            category: Union[str, Identifier]
             ) -> None:
-        """Create an InPartyCollection rule.
+        """Create an InPartyCategory rule.
 
         Args:
             party: A party.
-            collection: The collection it is in.
+            category: The category it is in.
         """
         if not isinstance(party, Identifier):
             party = Identifier(party)
         self.party = party
-        if not isinstance(collection, Identifier):
-            collection = Identifier(collection)
-        self.collection = collection
+        if not isinstance(category, Identifier):
+            category = Identifier(category)
+        self.category = category
+
+    def grouped(self) -> Identifier:
+        """Return the thing being grouped by this rule."""
+        return self.party
+
+    def group(self) -> Identifier:
+        """Return the grouping of the rule."""
+        return self.category
 
     def __repr__(self) -> str:
         """Return a string representation of this rule."""
-        return '("{}" is in "{}")'.format(self.party, self.collection)
+        return '("{}" is in "{}")'.format(self.party, self.category)
 
     def signing_representation(self) -> bytes:
         """Return a string of bytes representing the object.
 
         This adapts the Signable base class to this class.
         """
-        return '{}|{}'.format(self.party, self.collection).encode('utf-8')
+        return '{}|{}'.format(self.party, self.category).encode('utf-8')
 
     def signing_namespace(self) -> str:
         """Return the namespace whose owner must sign this rule."""
-        return self.collection.namespace()
+        return self.category.namespace()
 
 
 class InSiteCategory(GroupingRule):

--- a/mahiru/rest/serialization.py
+++ b/mahiru/rest/serialization.py
@@ -24,7 +24,7 @@ from mahiru.definitions.workflows import (
 
 from mahiru.policy.definitions import PolicyUpdate
 from mahiru.policy.rules import (
-        InAssetCollection, InAssetCategory, InPartyCollection, MayAccess,
+        InAssetCollection, InAssetCategory, InPartyCategory, MayAccess,
         ResultOfComputeIn, ResultOfDataIn)
 
 from mahiru.registry.replication import RegistryUpdate
@@ -122,13 +122,13 @@ def _serialize_in_asset_category(rule: InAssetCategory) -> JSON:
             'category': rule.category}
 
 
-def _serialize_in_party_collection(rule: InPartyCollection) -> JSON:
-    """Serialize an InPartyCollection object to JSON."""
+def _serialize_in_party_category(rule: InPartyCategory) -> JSON:
+    """Serialize an InPartyCategory object to JSON."""
     return {
-            'type': 'InPartyCollection',
+            'type': 'InPartyCategory',
             'signature': base64.urlsafe_b64encode(rule.signature).decode(),
             'party': rule.party,
-            'collection': rule.collection}
+            'category': rule.category}
 
 
 def _serialize_may_access(rule: MayAccess) -> JSON:
@@ -169,8 +169,8 @@ def _deserialize_rule(user_input: JSON) -> Rule:
         rule = InAssetCollection(user_input['asset'], user_input['collection'])
     elif user_input['type'] == 'InAssetCategory':
         rule = InAssetCategory(user_input['asset'], user_input['category'])
-    elif user_input['type'] == 'InPartyCollection':
-        rule = InPartyCollection(user_input['party'], user_input['collection'])
+    elif user_input['type'] == 'InPartyCategory':
+        rule = InPartyCategory(user_input['party'], user_input['category'])
     elif user_input['type'] == 'MayAccess':
         rule = MayAccess(user_input['site'], user_input['asset'])
     elif user_input['type'] == 'ResultOfDataIn':
@@ -446,7 +446,7 @@ _serializers = {
         SiteDescription: _serialize_site_description,
         InAssetCollection: _serialize_in_asset_collection,
         InAssetCategory: _serialize_in_asset_category,
-        InPartyCollection: _serialize_in_party_collection,
+        InPartyCategory: _serialize_in_party_category,
         MayAccess: _serialize_may_access,
         ResultOfDataIn: _serialize_result_of_data_in,
         ResultOfComputeIn: _serialize_result_of_compute_in,

--- a/tests/test_rule_replication.py
+++ b/tests/test_rule_replication.py
@@ -2,7 +2,7 @@ from copy import copy
 
 from mahiru.policy.replication import PolicyStore
 from mahiru.policy.rules import (
-        InAssetCollection, InPartyCollection, MayAccess, ResultOfDataIn,
+        InAssetCollection, InPartyCategory, MayAccess, ResultOfDataIn,
         ResultOfComputeIn)
 from mahiru.replication import ReplicableArchive
 from mahiru.definitions.policy import Rule
@@ -25,8 +25,8 @@ def test_rules_are_values():
     rule1 = InAssetCollection(
             'asset:party1_ns:data1:ns:s',
             'asset_collection:party1_ns:collection1')
-    rule2 = InPartyCollection(
-            'party:party2_ns:party2', 'party_collection:party2_ns:collection2')
+    rule2 = InPartyCategory(
+            'party:party2_ns:party2', 'party_category:party2_ns:collection2')
     rule3 = MayAccess('site:party3_ns:site3', 'asset:party3_ns:data3:ns:s')
 
     for rule in (rule1, rule2, rule3):

--- a/tests/test_rule_signatures.py
+++ b/tests/test_rule_signatures.py
@@ -1,5 +1,5 @@
 from mahiru.policy.rules import (
-        InAssetCollection, InPartyCollection, MayAccess, ResultOfDataIn)
+        InAssetCollection, InPartyCategory, MayAccess, ResultOfDataIn)
 
 
 def test_in_asset_collection_signatures(private_key):
@@ -18,9 +18,9 @@ def test_in_asset_collection_signatures(private_key):
 
 
 def test_in_party_collection_signatures(private_key):
-    rule = InPartyCollection(
+    rule = InPartyCategory(
             'party:ns1:party1',
-            'party_collection:ns1:collection.parties')
+            'party_category:ns1:category.parties')
     assert not rule.has_valid_signature(private_key.public_key())
     rule.sign(private_key)
     assert rule.has_valid_signature(private_key.public_key())
@@ -28,7 +28,7 @@ def test_in_party_collection_signatures(private_key):
     assert not rule.has_valid_signature(private_key.public_key())
     rule.party = 'party:ns1:party1'
     assert rule.has_valid_signature(private_key.public_key())
-    rule.collection = 'party_collection:ns2:collection.parties'
+    rule.category = 'party_category:ns2:category.parties'
     assert not rule.has_valid_signature(private_key.public_key())
 
 


### PR DESCRIPTION
This does a bit of refactoring. The PartyCollections we had turned out to make no sense, so that's been turned into PartyCategory, which we do need. Then there's a bug fix in the access checking, which didn't walk the hierarchy on one side as a result of which certain things that should have been allowed were forbidden. Finally, the functions for walking the hierarchy had a lot of overlap, and I saw a fairly clean way of combining them, so I did. Part of #87.