### PR TITLE
Issue 87: Improve policies - Part 4: may use

### DIFF
--- a/mahiru/components/ddm_site.py
+++ b/mahiru/components/ddm_site.py
@@ -95,5 +95,5 @@ class Site:
     def run_job(self, job: Job) -> Dict[str, Asset]:
         """Run a workflow on behalf of the party running this site."""
         logger.info('Starting job execution')
-        job_id = self.orchestrator.start_job(self.id, job)
+        job_id = self.orchestrator.start_job(self.owner, self.id, job)
         return self.orchestrator.get_results(job_id)

--- a/mahiru/components/orchestration.py
+++ b/mahiru/components/orchestration.py
@@ -34,14 +34,17 @@ class WorkflowPlanner:
         self._permission_calculator = PermissionCalculator(policy_evaluator)
 
     def make_plans(
-            self, submitter: Identifier, job: Job) -> List[Plan]:
+            self, submitting_party: Identifier, submitting_site: Identifier,
+            job: Job) -> List[Plan]:
         """Assigns a site to each workflow step.
 
         Uses the given result collections to determine where steps can
         be executed.
 
         Args:
-            submitter: Id of the site which submitted this, and to
+            submitting_party: Id of the party which submitted this, and
+                    who will use the results.
+            submitting_site: Id of the site which submitted this, and to
                     which results should be returned.
             job: The job to plan.
 
@@ -53,7 +56,8 @@ class WorkflowPlanner:
         # if we cannot access the outputs, then there are no plans
         for output in job.workflow.outputs:
             output_perms = permissions[output]
-            if not self._policy_evaluator.may_access(output_perms, submitter):
+            if not self._policy_evaluator.may_access(
+                    output_perms, submitting_site):
                 return []
 
         sites = self._registry_client.list_sites_with_runners()
@@ -211,17 +215,21 @@ class WorkflowOrchestrator:
         self._jobs = dict()     # type: Dict[str, ExecutionRequest]
         self._results = dict()  # type: Dict[str, Dict[str, Any]]
 
-    def start_job(self, submitter: Identifier, job: Job) -> str:
+    def start_job(
+            self, submitting_party: Identifier, submitting_site: Identifier,
+            job: Job) -> str:
         """Plans and executes the given workflow.
 
         Args:
-            submitter: The site to submit this job.
+            submitting_party: The party which submitted this job.
+            submitting_site: The site which submitted this job.
             job: The job to execute.
 
         Return:
             A string containing the new job's id.
         """
-        plans = self._planner.make_plans(submitter, job)
+        plans = self._planner.make_plans(
+                submitting_party, submitting_site, job)
         if not plans:
             logger.warning('No plans!')
             raise RuntimeError(

--- a/mahiru/components/orchestration.py
+++ b/mahiru/components/orchestration.py
@@ -53,11 +53,17 @@ class WorkflowPlanner:
         """
         permissions = self._permission_calculator.calculate_permissions(job)
 
-        # if we cannot access the outputs, then there are no plans
+        # if we cannot access or use the outputs, then there are no
+        # plans
         for output in job.workflow.outputs:
             output_perms = permissions[output]
             if not self._policy_evaluator.may_access(
                     output_perms, submitting_site):
+                logger.debug('Submitter may not access results')
+                return []
+            if not self._policy_evaluator.may_use(
+                    output_perms, submitting_party):
+                logger.debug('Submitter may not use results')
                 return []
 
         sites = self._registry_client.list_sites_with_runners()

--- a/mahiru/definitions/workflows.py
+++ b/mahiru/definitions/workflows.py
@@ -182,16 +182,18 @@ class Job:
     A Job is a workflow together with a set of inputs for it.
     """
     def __init__(
-            self, workflow: Workflow,
+            self, submitter: Identifier, workflow: Workflow,
             inputs: Mapping[str, Union[str, Identifier]]
             ) -> None:
         """Create a job.
 
         Args:
+            submitter: The party submitting this workflow.
             workflow: The workflow to run.
             inputs: A dictionary mapping the workflow's input
                     parameters to data set ids.
         """
+        self.submitter = submitter
         self.workflow = workflow
         self.inputs = {
                 inp: aid if isinstance(aid, Identifier) else Identifier(aid)
@@ -211,7 +213,9 @@ class Job:
 
         The job will have no steps, and a single input named `dataset`.
         """
-        return Job(Workflow(['dataset'], {}, []), {'dataset': asset_id})
+        return Job(
+                Identifier('*'), Workflow(['dataset'], {}, []),
+                {'dataset': asset_id})
 
     def subjob(
             self, step: WorkflowStep) -> 'Job':
@@ -229,7 +233,7 @@ class Job:
                 wf_inp: asset
                 for wf_inp, asset in self.inputs.items()
                 if wf_inp in sub_wf.inputs}
-        return Job(sub_wf, inputs)
+        return Job(self.submitter, sub_wf, inputs)
 
     def id_hashes(self) -> Dict[str, str]:
         """Calculates id hashes of all items in the job's workflow.

--- a/mahiru/policy/rules.py
+++ b/mahiru/policy/rules.py
@@ -227,6 +227,42 @@ class MayAccess(Rule):
         return self.asset.namespace()
 
 
+class MayUse(Rule):
+    """Says that Party party may use Asset asset."""
+    def __init__(
+            self, party: Union[str, Identifier], asset: Union[str, Identifier],
+            conditions: str) -> None:
+        """Create a MayUse rule.
+
+        Args:
+            party: The party that may access.
+            asset: The asset that may be accessed.
+            conditions: Conditions under which the asset may be used.
+        """
+        self.party = (
+                party if isinstance(party, Identifier) else Identifier(party))
+
+        if not isinstance(asset, Identifier):
+            asset = Identifier(asset)
+        self.asset = asset
+        self.conditions = conditions
+
+    def __repr__(self) -> str:
+        """Return a string representation of this rule."""
+        return f'("{self.party}" may use "{self.asset}")'
+
+    def signing_representation(self) -> bytes:
+        """Return a string of bytes representing the object.
+
+        This adapts the Signable base class to this class.
+        """
+        return f'{self.party}|{self.asset}|{self.conditions}'.encode('utf-8')
+
+    def signing_namespace(self) -> str:
+        """Return the namespace whose owner must sign this rule."""
+        return self.asset.namespace()
+
+
 class ResultOfIn(Rule):
     """Defines collections of results.
 

--- a/mahiru/rest/ddm_site.py
+++ b/mahiru/rest/ddm_site.py
@@ -466,20 +466,26 @@ class WorkflowSubmissionHandler:
             response: A response object to configure.
 
         """
-        if 'requester' not in request.params:
+        if (
+                'requesting_party' not in request.params or
+                'requesting_site' not in request.params):
             logger.info(f'Invalid job submission')
             response.status = HTTP_400
             response.body = 'Invalid request'
             return
 
-        requester = request.params['requester']
+        requesting_party = request.params['requesting_party']
+        requesting_site = request.params['requesting_site']
 
         try:
             validate_json('Job', request.media)
             job = deserialize(Job, request.media)
-            logger.info(f'Received new job {request.media} from {requester}')
-            job_id = self._orchestrator.start_job(requester, job)
-            logger.info(f'Received new job {job_id} from {requester}')
+            logger.info(
+                    f'Received new job {request.media} from'
+                    f' {requesting_party}')
+            job_id = self._orchestrator.start_job(
+                    requesting_party, requesting_site, job)
+            logger.info(f'Created new job {job_id} for {requesting_party}')
             response.status = HTTP_303
             response.location = _request_url(request) + '/' + job_id
         except ValidationError:

--- a/mahiru/rest/internal_client.py
+++ b/mahiru/rest/internal_client.py
@@ -22,14 +22,16 @@ _STANDARD_PORTS = {'http': 80, 'https': 443}
 
 class InternalSiteRestClient:
     """Handles connections to a local site."""
-    def __init__(self, site: str, endpoint: str) -> None:
+    def __init__(self, party: str, site: str, endpoint: str) -> None:
         """Create an InternalSiteRestClient.
 
         Args:
+            party: Party on whose behalf this client operates.
             site: Site this client is at.
             endpoint: Network location of the site's internal endpoint.
 
         """
+        self._party = party
         self._site = site
         self._endpoint = endpoint
 
@@ -80,7 +82,10 @@ class InternalSiteRestClient:
         """
         r = requests.post(
                 f'{self._endpoint}/jobs', json=serialize(job),
-                params={'requester': self._site}, allow_redirects=False)
+                params={
+                    'requesting_site': self._site,
+                    'requesting_party': self._party},
+                allow_redirects=False)
         if r.status_code != 303:
             raise RuntimeError(f'Error submitting job: {r.text}')
         if 'location' not in r.headers:

--- a/mahiru/rest/schemas.yaml
+++ b/mahiru/rest/schemas.yaml
@@ -72,6 +72,31 @@ components:
           description: Asset that may be accessed
           type: string
 
+    MayUse:
+      type: object
+      required:
+        - type
+        - signature
+        - party
+        - asset
+        - conditions
+      properties:
+        type:
+          description: Type of rule, always 'MayUse'
+          type: string
+        signature:
+          description: BASE64url serialised signature
+          type: string
+        party:
+          description: Id of the site that may access the asset
+          type: string
+        asset:
+          description: Asset that may be accessed
+          type: string
+        conditions:
+          description: Conditions of use
+          type: string
+
     ResultOfIn:
       type: object
       required:
@@ -106,6 +131,7 @@ components:
         - $ref: '#/components/schemas/InAssetCollection'
         - $ref: '#/components/schemas/InPartyCollection'
         - $ref: '#/components/schemas/MayAccess'
+        - $ref: '#/components/schemas/MayUse'
         - $ref: '#/components/schemas/ResultOfIn'
 
     PolicyUpdate:
@@ -135,6 +161,7 @@ components:
               - "$ref": "#/components/schemas/InAssetCollection"
               - "$ref": "#/components/schemas/InPartyCollection"
               - "$ref": "#/components/schemas/MayAccess"
+              - "$ref": "#/components/schemas/MayUse"
               - "$ref": "#/components/schemas/ResultOfIn"
         deleted:
           description: Objects that were deleted since the last version
@@ -144,6 +171,7 @@ components:
               - "$ref": "#/components/schemas/InAssetCollection"
               - "$ref": "#/components/schemas/InPartyCollection"
               - "$ref": "#/components/schemas/MayAccess"
+              - "$ref": "#/components/schemas/MayUse"
               - "$ref": "#/components/schemas/ResultOfIn"
 
     ComputeMetadata:

--- a/mahiru/rest/serialization.py
+++ b/mahiru/rest/serialization.py
@@ -225,14 +225,15 @@ def _deserialize_workflow(user_input: JSON) -> Workflow:
 def _serialize_job(job: Job) -> JSON:
     """Serialize a Job to JSON."""
     return {
-           'workflow': _serialize_workflow(job.workflow),
-           'inputs': job.inputs}
+            'submitter': job.submitter,
+            'workflow': _serialize_workflow(job.workflow),
+            'inputs': job.inputs}
 
 
 def _deserialize_job(user_input: JSON) -> Job:
     """Deserialize a Job from JSON."""
     workflow = _deserialize_workflow(user_input['workflow'])
-    return Job(workflow, user_input['inputs'])
+    return Job(user_input['submitter'], workflow, user_input['inputs'])
 
 
 def _serialize_plan(plan: Plan) -> JSON:

--- a/mahiru/rest/serialization.py
+++ b/mahiru/rest/serialization.py
@@ -24,7 +24,7 @@ from mahiru.definitions.workflows import (
 
 from mahiru.policy.definitions import PolicyUpdate
 from mahiru.policy.rules import (
-        InAssetCollection, InAssetCategory, InPartyCategory, MayAccess,
+        InAssetCollection, InAssetCategory, InPartyCategory, MayAccess, MayUse,
         ResultOfComputeIn, ResultOfDataIn)
 
 from mahiru.registry.replication import RegistryUpdate
@@ -140,6 +140,16 @@ def _serialize_may_access(rule: MayAccess) -> JSON:
             'asset': rule.asset}
 
 
+def _serialize_may_use(rule: MayUse) -> JSON:
+    """Serialize a MayUse object to JSON."""
+    return {
+            'type': 'MayUse',
+            'signature': base64.urlsafe_b64encode(rule.signature).decode(),
+            'party': rule.party,
+            'asset': rule.asset,
+            'conditions': rule.conditions}
+
+
 def _serialize_result_of_data_in(rule: ResultOfDataIn) -> JSON:
     """Serialize a ResultOfDataIn object to JSON."""
     return {
@@ -173,6 +183,10 @@ def _deserialize_rule(user_input: JSON) -> Rule:
         rule = InPartyCategory(user_input['party'], user_input['category'])
     elif user_input['type'] == 'MayAccess':
         rule = MayAccess(user_input['site'], user_input['asset'])
+    elif user_input['type'] == 'MayUse':
+        rule = MayUse(
+                user_input['party'], user_input['asset'],
+                user_input['conditions'])
     elif user_input['type'] == 'ResultOfDataIn':
         rule = ResultOfDataIn(
                 user_input['data_asset'], user_input['compute_asset'],
@@ -449,6 +463,7 @@ _serializers = {
         InAssetCategory: _serialize_in_asset_category,
         InPartyCategory: _serialize_in_party_category,
         MayAccess: _serialize_may_access,
+        MayUse: _serialize_may_use,
         ResultOfDataIn: _serialize_result_of_data_in,
         ResultOfComputeIn: _serialize_result_of_compute_in,
         WorkflowStep: _serialize_workflow_step,

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -18,7 +18,7 @@ from mahiru.definitions.identifier import Identifier
 from mahiru.definitions.registry import PartyDescription, SiteDescription
 from mahiru.definitions.workflows import Job, Workflow, WorkflowStep
 from mahiru.policy.rules import (
-        MayAccess, ResultOfComputeIn, ResultOfDataIn)
+        MayAccess, MayUse, ResultOfComputeIn, ResultOfDataIn)
 from mahiru.rest.ddm_site import SiteRestApi, SiteServer
 from mahiru.rest.internal_client import InternalSiteRestClient
 
@@ -97,7 +97,9 @@ def run_container_step(
                 '*', 'asset:ns:compute1:ns:test_site', '*',
                 'asset_collection:ns:public'),
             MayAccess('site:ns:test_site', 'asset_collection:ns:results1'),
-            MayAccess('*', 'asset_collection:ns:public')]
+            MayUse('party:ns:test_party', 'asset_collection:ns:results1', ''),
+            MayAccess('*', 'asset_collection:ns:public'),
+            MayUse('*', 'asset_collection:ns:public', 'For any use')]
 
     for rule in rules:
         rule.sign(party_key)

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -16,7 +16,7 @@ from mahiru.definitions.identifier import Identifier
 from mahiru.definitions.registry import PartyDescription, SiteDescription
 from mahiru.definitions.workflows import Job, WorkflowStep, Workflow
 from mahiru.policy.rules import (
-    InAssetCollection, MayAccess, ResultOfDataIn,
+    InAssetCollection, MayAccess, MayUse, ResultOfDataIn,
     ResultOfComputeIn)
 from mahiru.rest.ddm_site import SiteRestApi, SiteServer
 from mahiru.rest.internal_client import InternalSiteRestClient
@@ -276,18 +276,34 @@ def test_pii(registry_server, registry_client, registration_client):
             MayAccess(
                 'site:ddm_ns:site3',
                 'asset_collection:ddm_ns:collection.ScienceOnly'),
+            MayUse(
+                'party:party2_ns:party2',
+                'asset_collection:ddm_ns:collection.ScienceOnly',
+                'Only for non-commercial scientific purposes'),
 
             MayAccess(
                 'site:party1_ns:site1',
                 'asset_collection:ddm_ns:collection.Public'),
+            MayUse(
+                'party:party1_ns:party1',
+                'asset_collection:ddm_ns:collection.Public',
+                'For any purpose'),
 
             MayAccess(
                 'site:party2_ns:site2',
                 'asset_collection:ddm_ns:collection.Public'),
+            MayUse(
+                'party:party2_ns:party2',
+                'asset_collection:ddm_ns:collection.Public',
+                'For any purpose'),
 
             MayAccess(
                 'site:ddm_ns:site3',
                 'asset_collection:ddm_ns:collection.Public'),
+            MayUse(
+                'party:party3_ns:party3',
+                'asset_collection:ddm_ns:collection.Public',
+                'For any purpose'),
             ]
 
     scenario['sites'] = {
@@ -380,6 +396,10 @@ def test_saas_with_data(registry_server, registry_client, registration_client):
             MayAccess(
                 'site:party2_ns:site2',
                 'asset_collection:party1_ns:collection.result1'),
+            MayUse(
+                'party:party1_ns:party1',
+                'asset_collection:party1_ns:collection.result1',
+                'For any use'),
             ]
 
     scenario['rules-party2'] = [
@@ -410,6 +430,10 @@ def test_saas_with_data(registry_server, registry_client, registration_client):
             MayAccess(
                 'site:party2_ns:site2',
                 'asset:party2_ns:software.addition:party2_ns:site2'),
+            MayUse(
+                'party:party1_ns:party1',
+                'asset_collection:party2_ns:collection.result2',
+                'For any use'),
             ]
 
     scenario['sites'] = {

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -12,6 +12,7 @@ from mahiru.components.ddm_site import Site
 from mahiru.components.registry_client import RegistryClient
 from mahiru.components.settings import NetworkSettings, SiteConfiguration
 from mahiru.definitions.assets import ComputeAsset, DataAsset
+from mahiru.definitions.identifier import Identifier
 from mahiru.definitions.registry import PartyDescription, SiteDescription
 from mahiru.definitions.workflows import Job, WorkflowStep, Workflow
 from mahiru.policy.rules import (
@@ -95,7 +96,8 @@ def create_clients(servers: Dict[str, SiteServer], sites: Dict[str, Site]):
     """Create internal REST clients for sites."""
     return {
             site_name: InternalSiteRestClient(
-                sites[site_name].id, server.internal_endpoint)
+                sites[site_name].owner, sites[site_name].id,
+                server.internal_endpoint)
             for site_name, server in servers.items()}
 
 
@@ -274,12 +276,15 @@ def test_pii(registry_server, registry_client, registration_client):
             MayAccess(
                 'site:ddm_ns:site3',
                 'asset_collection:ddm_ns:collection.ScienceOnly'),
+
             MayAccess(
                 'site:party1_ns:site1',
                 'asset_collection:ddm_ns:collection.Public'),
+
             MayAccess(
                 'site:party2_ns:site2',
                 'asset_collection:ddm_ns:collection.Public'),
+
             MayAccess(
                 'site:ddm_ns:site3',
                 'asset_collection:ddm_ns:collection.Public'),
@@ -342,7 +347,8 @@ def test_pii(registry_server, registry_client, registration_client):
             'x1': 'asset:party1_ns:dataset.pii1:party1_ns:site1',
             'x2': 'asset:party2_ns:dataset.pii2:party2_ns:site2'}
 
-    scenario['job'] = Job(workflow, inputs)
+    scenario['job'] = Job(
+            Identifier('party:party2_ns:party2'), workflow, inputs)
     scenario['user_site'] = 'site2'
 
     output = run_scenario(scenario, registry_client, registration_client)
@@ -440,7 +446,8 @@ def test_saas_with_data(registry_server, registry_client, registration_client):
             'x1': 'asset:party1_ns:dataset.data1:party1_ns:site1',
             'x2': 'asset:party2_ns:dataset.data2:party2_ns:site2'}
 
-    scenario['job'] = Job(workflow, inputs)
+    scenario['job'] = Job(
+            Identifier('party:party1_ns:party1'), workflow, inputs)
     scenario['user_site'] = 'site1'
 
     output = run_scenario(scenario, registry_client, registration_client)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -83,3 +83,8 @@ def test_wf_output_checks():
     workflow.outputs['y'] = 'anonymise.y'
     plans = planner.make_plans('party:ns2:party2', 'site:ns2:s2', job)
     assert plans == []
+
+    # test that use permission is needed
+    workflow.outputs['y'] = 'aggregate.y'
+    plans = planner.make_plans('party:ns1:party1', 'site:ns1:s1', job)
+    assert plans == []

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -5,7 +5,8 @@ from mahiru.definitions.identifier import Identifier
 from mahiru.definitions.workflows import Job, Workflow, WorkflowStep
 from mahiru.policy.evaluation import PolicyEvaluator
 from mahiru.components.orchestration import WorkflowPlanner
-from mahiru.policy.rules import MayAccess, ResultOfDataIn, ResultOfComputeIn
+from mahiru.policy.rules import (
+        MayAccess, MayUse, ResultOfDataIn, ResultOfComputeIn)
 
 
 class MockPolicySource:
@@ -30,11 +31,14 @@ def test_wf_output_checks():
     rules = [
             MayAccess('site:ns1:s1', 'asset:ns:Anonymise:ns:s'),
             MayAccess('site:ns1:s1', 'asset:ns:Aggregate:ns:s'),
+
             ResultOfDataIn(
                 'asset_collection:ns:Public', '*', '*',
                 'asset_collection:ns:Public'),
             MayAccess('site:ns1:s1', 'asset_collection:ns:Public'),
             MayAccess('site:ns2:s2', 'asset_collection:ns:Public'),
+            MayUse('party:ns2:party2', 'asset_collection:ns:Public', ''),
+
             MayAccess('site:ns1:s1', 'asset:ns1:dataset.d1:ns1:s1'),
             ResultOfDataIn(
                 'asset:ns1:dataset.d1:ns1:s1', 'asset:ns:Anonymise:ns:s', 'y',
@@ -51,6 +55,7 @@ def test_wf_output_checks():
                 'asset_collection:ns:Public'),
             MayAccess('site:ns1:s1', 'asset_collection:ns1:Aggregated'),
             MayAccess('site:ns2:s2', 'asset_collection:ns1:Aggregated'),
+            MayUse('party:ns2:party2', 'asset_collection:ns1:Aggregated', ''),
             ]
     policy_evaluator = PolicyEvaluator(MockPolicySource(rules))
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 from mahiru.definitions.assets import ComputeAsset
+from mahiru.definitions.identifier import Identifier
 from mahiru.definitions.workflows import Job, Workflow, WorkflowStep
 from mahiru.policy.evaluation import PolicyEvaluator
 from mahiru.components.orchestration import WorkflowPlanner
@@ -64,14 +65,16 @@ def test_wf_output_checks():
                              inputs={'x1': 'anonymise.y'},
                              outputs={'y': None},
                              compute_asset_id='asset:ns:Aggregate:ns:s')])
-    job = Job(workflow, {'x': 'asset:ns1:dataset.d1:ns1:s1'})
+    job = Job(
+            Identifier('party:ns2:party2'), workflow,
+            {'x': 'asset:ns1:dataset.d1:ns1:s1'})
     planner = WorkflowPlanner(mock_client, policy_evaluator)
-    plans = planner.make_plans('site:ns2:s2', job)
+    plans = planner.make_plans('party:ns2:party2', 'site:ns2:s2', job)
     assert len(plans) == 1
     assert plans[0].step_sites['anonymise'] == 'site:ns1:s1'
     assert plans[0].step_sites['aggregate'] == 'site:ns1:s1'
 
     # test output from intermediate step
     workflow.outputs['y'] = 'anonymise.y'
-    plans = planner.make_plans('site:ns2:s2', job)
+    plans = planner.make_plans('party:ns2:party2', 'site:ns2:s2', job)
     assert plans == []


### PR DESCRIPTION
This finally adds the usage checking functionality, the last bit of #87. To check that the submitter of the workflow has use rights to the outputs, we need to know who it is, so we add the submitting party to the Job class. Sending an identifier is obviously not very secure, but this will be replaced by a signature when we add certificates. Then there's the MayUse rule, and the logic for evaluating it.