### PR TITLE
Issue 119: Include rule types in signature hashes

### DIFF
--- a/mahiru/components/settings.py
+++ b/mahiru/components/settings.py
@@ -81,6 +81,10 @@ class SiteConfiguration:
             loglevel: Logging level to use, one of 'critical', 'error',
                     'warning', 'info', or 'debug'.
         """
+        if owner.kind() != 'party':
+            raise ValueError(
+                    'Expected a name of the form "party:<namespace>:<name>"')
+
         self.name = name
         self.namespace = namespace
         self.owner = owner

--- a/mahiru/definitions/identifier.py
+++ b/mahiru/definitions/identifier.py
@@ -65,6 +65,10 @@ class Identifier(str):
         """Return the list of segments of this identifier."""
         return self.split(':')
 
+    def kind(self) -> str:
+        """Returns the kind of identifier this is."""
+        return self.segments[0]
+
     def namespace(self) -> str:
         """Returns the namespace part of the identifier.
 

--- a/mahiru/policy/rules.py
+++ b/mahiru/policy/rules.py
@@ -64,7 +64,8 @@ class InAssetCollection(GroupingRule):
 
         This adapts the Signable base class to this class.
         """
-        return '{}|{}'.format(self.asset, self.collection).encode('utf-8')
+        return 'InAssetCollection|{}|{}'.format(
+                self.asset, self.collection).encode('utf-8')
 
     def signing_namespace(self) -> str:
         """Return the namespace whose owner must sign this rule."""
@@ -112,7 +113,8 @@ class InAssetCategory(GroupingRule):
 
         This adapts the Signable base class to this class.
         """
-        return '{}|{}'.format(self.asset, self.category).encode('utf-8')
+        return 'InAssetCategory|{}|{}'.format(
+                self.asset, self.category).encode('utf-8')
 
     def signing_namespace(self) -> str:
         """Return the namespace whose owner must sign this rule."""
@@ -160,7 +162,8 @@ class InPartyCategory(GroupingRule):
 
         This adapts the Signable base class to this class.
         """
-        return '{}|{}'.format(self.party, self.category).encode('utf-8')
+        return 'InPartyCategory|{}|{}'.format(
+                self.party, self.category).encode('utf-8')
 
     def signing_namespace(self) -> str:
         """Return the namespace whose owner must sign this rule."""
@@ -208,7 +211,8 @@ class InSiteCategory(GroupingRule):
 
         This adapts the Signable base class to this class.
         """
-        return '{}|{}'.format(self.site, self.category).encode('utf-8')
+        return 'InSiteCategory|{}|{}'.format(
+                self.site, self.category).encode('utf-8')
 
     def signing_namespace(self) -> str:
         """Return the namespace whose owner must sign this rule."""
@@ -247,7 +251,7 @@ class MayAccess(Rule):
 
         This adapts the Signable base class to this class.
         """
-        return f'{self.site}|{self.asset}'.encode('utf-8')
+        return f'MayAccess|{self.site}|{self.asset}'.encode('utf-8')
 
     def signing_namespace(self) -> str:
         """Return the namespace whose owner must sign this rule."""
@@ -289,7 +293,8 @@ class MayUse(Rule):
 
         This adapts the Signable base class to this class.
         """
-        return f'{self.party}|{self.asset}|{self.conditions}'.encode('utf-8')
+        return 'MayUse|{}|{}|{}'.format(
+                self.party, self.asset, self.conditions).encode('utf-8')
 
     def signing_namespace(self) -> str:
         """Return the namespace whose owner must sign this rule."""
@@ -339,15 +344,6 @@ class ResultOfIn(Rule):
                 self.output, self.compute_asset, self.data_asset,
                 self.collection)
 
-    def signing_representation(self) -> bytes:
-        """Return a string of bytes representing the object.
-
-        This adapts the Signable base class to this class.
-        """
-        return '{}|{}|{}|{}'.format(
-                self.data_asset, self.compute_asset, self.output,
-                self.collection).encode('utf-8')
-
 
 class ResultOfDataIn(ResultOfIn):
     """ResultOfIn rule on behalf of the data asset owner."""
@@ -385,6 +381,15 @@ class ResultOfDataIn(ResultOfIn):
         """Return the namespace whose owner must sign this rule."""
         return self.data_asset.namespace()
 
+    def signing_representation(self) -> bytes:
+        """Return a string of bytes representing the object.
+
+        This adapts the Signable base class to this class.
+        """
+        return 'ResultOfDataIn|{}|{}|{}|{}'.format(
+                self.data_asset, self.compute_asset, self.output,
+                self.collection).encode('utf-8')
+
 
 class ResultOfComputeIn(ResultOfIn):
     """ResultOfIn rule on behalf of the compute asset owner."""
@@ -421,3 +426,12 @@ class ResultOfComputeIn(ResultOfIn):
     def signing_namespace(self) -> str:
         """Return the namespace whose owner must sign this rule."""
         return self.compute_asset.namespace()
+
+    def signing_representation(self) -> bytes:
+        """Return a string of bytes representing the object.
+
+        This adapts the Signable base class to this class.
+        """
+        return 'ResultOfComputeIn|{}|{}|{}|{}'.format(
+                self.data_asset, self.compute_asset, self.output,
+                self.collection).encode('utf-8')

--- a/mahiru/policy/rules.py
+++ b/mahiru/policy/rules.py
@@ -37,9 +37,14 @@ class InAssetCollection(GroupingRule):
         """
         if not isinstance(asset, Identifier):
             asset = Identifier(asset)
+        if asset.kind() not in ('asset', 'asset_collection'):
+            raise ValueError(f'Invalid asset kind {asset.kind()}')
         self.asset = asset
+
         if not isinstance(collection, Identifier):
             collection = Identifier(collection)
+        if collection.kind() != 'asset_collection':
+            raise ValueError(f'Invalid collection kind {collection.kind()}')
         self.collection = collection
 
     def __repr__(self) -> str:
@@ -80,9 +85,14 @@ class InAssetCategory(GroupingRule):
         """
         if not isinstance(asset, Identifier):
             asset = Identifier(asset)
+        if asset.kind() not in ('asset', 'asset_category'):
+            raise ValueError(f'Invalid asset kind {asset.kind()}')
         self.asset = asset
+
         if not isinstance(category, Identifier):
             category = Identifier(category)
+        if category.kind() != 'asset_category':
+            raise ValueError(f'Invalid category kind {category.kind()}')
         self.category = category
 
     def grouped(self) -> Identifier:
@@ -123,9 +133,14 @@ class InPartyCategory(GroupingRule):
         """
         if not isinstance(party, Identifier):
             party = Identifier(party)
+        if party.kind() not in ('party', 'party_category'):
+            raise ValueError(f'Invalid party kind {party.kind()}')
         self.party = party
+
         if not isinstance(category, Identifier):
             category = Identifier(category)
+        if category.kind() != 'party_category':
+            raise ValueError(f'Invalid category kind {category.kind()}')
         self.category = category
 
     def grouped(self) -> Identifier:
@@ -166,9 +181,14 @@ class InSiteCategory(GroupingRule):
         """
         if not isinstance(site, Identifier):
             site = Identifier(site)
+        if site.kind() not in ('site', 'site_category'):
+            raise ValueError(f'Invalid site kind {site.kind()}')
         self.site = site
+
         if not isinstance(category, Identifier):
             category = Identifier(category)
+        if category.kind() != 'site_category':
+            raise ValueError(f'Invalid category kind {site.kind()}')
         self.category = category
 
     def grouped(self) -> Identifier:
@@ -206,9 +226,16 @@ class MayAccess(Rule):
             site: The site that may access.
             asset: The asset that may be accessed.
         """
-        self.site = site if isinstance(site, Identifier) else Identifier(site)
+        if not isinstance(site, Identifier):
+            site = Identifier(site)
+        if site.kind() not in ('site', 'site_category', '*'):
+            raise ValueError(f'Invalid site kind {site.kind()}')
+        self.site = site
+
         if not isinstance(asset, Identifier):
             asset = Identifier(asset)
+        if asset.kind() not in ('asset', 'asset_collection'):
+            raise ValueError(f'Invalid asset kind {asset.kind()}')
         self.asset = asset
 
     def __repr__(self) -> str:
@@ -239,12 +266,18 @@ class MayUse(Rule):
             asset: The asset that may be accessed.
             conditions: Conditions under which the asset may be used.
         """
-        self.party = (
-                party if isinstance(party, Identifier) else Identifier(party))
+        if not isinstance(party, Identifier):
+            party = Identifier(party)
+        if party.kind() not in ('party', 'party_category', '*'):
+            raise ValueError(f'Invalid party kind {party.kind()}')
+        self.party = party
 
         if not isinstance(asset, Identifier):
             asset = Identifier(asset)
+        if asset.kind() not in ('asset', 'asset_collection'):
+            raise ValueError(f'Invalid asset kind {asset.kind()}')
         self.asset = asset
+
         self.conditions = conditions
 
     def __repr__(self) -> str:
@@ -318,6 +351,36 @@ class ResultOfIn(Rule):
 
 class ResultOfDataIn(ResultOfIn):
     """ResultOfIn rule on behalf of the data asset owner."""
+    def __init__(
+            self,
+            data_asset: Union[str, Identifier],
+            compute_asset: Union[str, Identifier],
+            output: str,
+            collection: Union[str, Identifier]
+            ) -> None:
+        """Create a ResultOfDataIn rule.
+
+        Args:
+            data_asset: The source data asset.
+            compute_asset: The compute asset used to process the data.
+            output: The name of the workflow step output that produced
+                    the result Asset, or '*' to match any output.
+            collection: The output collection.
+        """
+        super().__init__(data_asset, compute_asset, output, collection)
+
+        if self.data_asset.kind() not in ('asset', 'asset_collection'):
+            raise ValueError(
+                    f'Invalid data asset kind {self.data_asset.kind()}')
+
+        if self.compute_asset.kind() not in ('asset', 'asset_category', '*'):
+            raise ValueError(
+                    f'Invalid compute asset kind {self.compute_asset.kind()}')
+
+        if self.collection.kind() != 'asset_collection':
+            raise ValueError(
+                    f'Invalid collection kind {self.collection.kind()}')
+
     def signing_namespace(self) -> str:
         """Return the namespace whose owner must sign this rule."""
         return self.data_asset.namespace()
@@ -325,6 +388,36 @@ class ResultOfDataIn(ResultOfIn):
 
 class ResultOfComputeIn(ResultOfIn):
     """ResultOfIn rule on behalf of the compute asset owner."""
+    def __init__(
+            self,
+            data_asset: Union[str, Identifier],
+            compute_asset: Union[str, Identifier],
+            output: str,
+            collection: Union[str, Identifier]
+            ) -> None:
+        """Create a ResultOfDataIn rule.
+
+        Args:
+            data_asset: The source data asset.
+            compute_asset: The compute asset used to process the data.
+            output: The name of the workflow step output that produced
+                    the result Asset, or '*' to match any output.
+            collection: The output collection.
+        """
+        super().__init__(data_asset, compute_asset, output, collection)
+
+        if self.data_asset.kind() not in ('asset', 'asset_category', '*'):
+            raise ValueError(
+                    f'Invalid data asset kind {self.data_asset.kind()}')
+
+        if self.compute_asset.kind() not in ('asset', 'asset_collection'):
+            raise ValueError(
+                    f'Invalid compute asset kind {self.compute_asset.kind()}')
+
+        if self.collection.kind() != 'asset_collection':
+            raise ValueError(
+                    f'Invalid collection kind {self.collection.kind()}')
+
     def signing_namespace(self) -> str:
         """Return the namespace whose owner must sign this rule."""
         return self.compute_asset.namespace()

--- a/tests/test_policy_evaluation.py
+++ b/tests/test_policy_evaluation.py
@@ -152,9 +152,14 @@ def test_asset_collection_access(asset1, asset_collection1a, site1, site2):
 
 
 def test_asset_category_access(asset1, asset_category1a, site1):
+    # Make a broken rule and check that we don't follow categories
+    # even if that happens.
+    may_access = MayAccess(site1, 'asset:dummy:dummy:dummy:dummy')
+    may_access.asset = asset_category1a
+
     policies = MockPolicies([
         InAssetCategory(asset1, asset_category1a),
-        MayAccess(site1, asset_category1a)])
+        may_access])
     evaluator = PolicyEvaluator(policies)
 
     perms = evaluator.permissions_for_asset(asset1)
@@ -174,9 +179,13 @@ def test_site_category_access(asset1, site_category1a, site2):
 
 
 def test_asset_category_any_site(any_object, asset1, asset_category1a, site1):
+    # Make a broken rule and check that we don't follow categories
+    # even if that happens, and also to any site.
+    may_access = MayAccess(any_object, 'asset:dummy:dummy:dummy:dummy')
+    may_access.asset = asset_category1a
     policies = MockPolicies([
         InAssetCategory(asset1, asset_category1a),
-        MayAccess(any_object, asset_category1a)])
+        may_access])
     evaluator = PolicyEvaluator(policies)
 
     perms = evaluator.permissions_for_asset(asset1)
@@ -212,10 +221,12 @@ def test_propagate_result_of_data_in_data_collection(
 
 def test_propagate_result_of_data_in_data_category(
         asset1, asset2, asset_category1a, asset_collection1a):
+    rodi = ResultOfDataIn(asset1, asset2, 'output1', asset_collection1a)
+    rodi.data_asset = asset_category1a
+
     policies = MockPolicies([
         InAssetCategory(asset1, asset_category1a),
-        ResultOfDataIn(
-            asset_category1a, asset2, 'output1', asset_collection1a)])
+        rodi])
     evaluator = PolicyEvaluator(policies)
 
     input_perms = [Permissions([{asset1}])]
@@ -225,10 +236,12 @@ def test_propagate_result_of_data_in_data_category(
 
 def test_propagate_result_of_data_in_compute_collection(
         asset1, asset2, asset_collection1a, asset_collection1b):
+    rodi = ResultOfDataIn(asset2, asset1, 'output1', asset_collection1b)
+    rodi.compute_asset = asset_collection1a
+
     policies = MockPolicies([
         InAssetCollection(asset1, asset_collection1a),
-        ResultOfDataIn(
-            asset2, asset_collection1a, 'output1', asset_collection1b)])
+        rodi])
     evaluator = PolicyEvaluator(policies)
 
     input_perms = [Permissions([{asset2}])]
@@ -261,10 +274,12 @@ def test_propagate_result_of_compute_in(asset1, asset2, asset_collection2a):
 
 def test_propagate_result_of_compute_in_data_collection(
         asset1, asset2, asset_collection1a, asset_collection2a):
+    roci = ResultOfComputeIn(asset1, asset2, 'output1', asset_collection2a)
+    roci.data_asset = asset_collection1a
+
     policies = MockPolicies([
         InAssetCollection(asset1, asset_collection1a),
-        ResultOfComputeIn(
-            asset_collection1a, asset2, 'output1', asset_collection2a)])
+        roci])
     evaluator = PolicyEvaluator(policies)
 
     input_perms = [Permissions([{asset1}])]
@@ -300,10 +315,12 @@ def test_propagate_result_of_compute_in_compute_collection(
 
 def test_propagate_result_of_compute_in_compute_category(
         asset1, asset2, asset_collection1a, asset_category1a):
+    roci = ResultOfComputeIn(asset2, asset1, 'output1', asset_collection1a)
+    roci.compute_asset = asset_category1a
+
     policies = MockPolicies([
         InAssetCategory(asset1, asset_category1a),
-        ResultOfComputeIn(
-            asset2, asset_category1a, 'output1', asset_collection1a)])
+        roci])
     evaluator = PolicyEvaluator(policies)
 
     input_perms = [Permissions([{asset2}])]

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -70,7 +70,7 @@ def create_sites(
     return {
             site_name: Site(
                 SiteConfiguration(
-                    site_name, desc['namespace'], desc['owner'],
+                    site_name, desc['namespace'], Identifier(desc['owner']),
                     NetworkSettings(), ''),
                 [], [], registry_client)
             for site_name, desc in site_descriptions.items()}


### PR DESCRIPTION
This fixes #119, and while we're here adds identifier type checks on the rule classes so that when we receive rules from others, we'll check to make sure that they're not sending us nonsense.